### PR TITLE
Ensure authentication check on app launch

### DIFF
--- a/lib/features/auth/login_page.dart
+++ b/lib/features/auth/login_page.dart
@@ -11,14 +11,14 @@ class _SocialButton extends StatelessWidget {
   const _SocialButton({
     required this.text,
     required this.color,
-    required this.onTap,
+    this.onTap,
     this.textColor,
   });
 
   final String text;
   final Color color;
   final Color? textColor;
-  final VoidCallback onTap;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) => SizedBox(
@@ -80,6 +80,12 @@ class _EmailPasswordFormState extends ConsumerState<_EmailPasswordForm> {
   bool _busy = false;
   bool _signUpMode = false;
 
+  Future<void> _signInWith(AuthProvider provider) async {
+    setState(() => _busy = true);
+    await ref.read(authProvider.notifier).signInWithProvider(provider);
+    if (mounted) setState(() => _busy = false);
+  }
+
   Future<void> _submit() async {
     if (!_form.currentState!.validate()) return;
 
@@ -132,17 +138,13 @@ class _EmailPasswordFormState extends ConsumerState<_EmailPasswordForm> {
                   text: 'Continue with Google',
                   color: Colors.white,
                   textColor: Colors.black87,
-                  onTap: () => ref
-                      .read(authProvider.notifier)
-                      .signInWithProvider(AuthProvider.google),
+                  onTap: _busy ? null : () => _signInWith(AuthProvider.google),
                 ),
                 const SizedBox(height: 12),
                 _SocialButton(
                   text: 'Continue with Facebook',
                   color: const Color(0xFF1877F2),
-                  onTap: () => ref
-                      .read(authProvider.notifier)
-                      .signInWithProvider(AuthProvider.facebook),
+                  onTap: _busy ? null : () => _signInWith(AuthProvider.facebook),
                 ),
 
                 const SizedBox(height: 24),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,7 @@ import 'package:google_fonts/google_fonts.dart';
 
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'router.dart';                       // your GoRouter tree
-import 'ui/auth_gate.dart';
+import 'features/auth/login_page.dart';
 import 'shared/providers/auth_provider.dart';
 import 'shared/providers/locale_notifier.dart';   // step 6
 
@@ -56,6 +56,7 @@ class _BootstrapperState extends ConsumerState<_Bootstrapper> {
   @override
   Widget build(BuildContext context) {
     final locale = ref.watch(localeNotifierProvider).locale;
+    final auth   = ref.watch(authProvider);
 
     final baseTheme = ThemeData(
       useMaterial3: true,
@@ -63,9 +64,42 @@ class _BootstrapperState extends ConsumerState<_Bootstrapper> {
       textTheme: GoogleFonts.poppinsTextTheme(),
     );
 
-    final app = MaterialApp.router(
+    if (!_ampReady || auth.status == AuthStatus.unknown) {
+      return MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: baseTheme,
+        locale: locale,
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        home: const Scaffold(
+          body: Center(child: CircularProgressIndicator()),
+        ),
+      );
+    }
+
+    if (auth.status == AuthStatus.authenticated) {
+      return MaterialApp.router(
+        debugShowCheckedModeBanner: false,
+        routerConfig: createRouter(),
+        theme: baseTheme,
+        locale: locale,
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+      );
+    }
+
+    return MaterialApp(
       debugShowCheckedModeBanner: false,
-      routerConfig: createRouter(),             // your existing GoRouter factory
       theme: baseTheme,
       locale: locale,
       supportedLocales: AppLocalizations.supportedLocales,
@@ -75,25 +109,7 @@ class _BootstrapperState extends ConsumerState<_Bootstrapper> {
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,
       ],
+      home: const LoginPage(),
     );
-
-    // While Amplify is starting up, show a simple loading shell.
-    return _ampReady
-        ? app
-        : MaterialApp(
-            debugShowCheckedModeBanner: false,
-            theme: baseTheme,
-            locale: locale,
-            supportedLocales: AppLocalizations.supportedLocales,
-            localizationsDelegates: const [
-              AppLocalizations.delegate,
-              GlobalMaterialLocalizations.delegate,
-              GlobalWidgetsLocalizations.delegate,
-              GlobalCupertinoLocalizations.delegate,
-            ],
-            home: const Scaffold(
-              body: Center(child: CircularProgressIndicator()),
-            ),
-          );
   }
 }

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -112,6 +112,10 @@ final router = GoRouter(
 
       ],
     ),
+    GoRoute(
+      path: '/login',
+      builder: (_, __) => const LoginPage(),
+    ),
   ],
 );
 

--- a/lib/shared/providers/auth_provider.dart
+++ b/lib/shared/providers/auth_provider.dart
@@ -120,8 +120,12 @@ class AuthNotifier extends StateNotifier<AuthState> {
 
   Future<void> signInWithProvider(AuthProvider provider) async {
     try {
-      await Amplify.Auth.signInWithWebUI(provider: provider);
-      state = const AuthState.authenticated();
+      final res = await Amplify.Auth.signInWithWebUI(provider: provider);
+      if (res.isSignedIn) {
+        state = const AuthState.authenticated();
+      } else {
+        await _checkLoginStatus();
+      }
     } on AuthException catch (e) {
       state = AuthState.error(e.message);
     }


### PR DESCRIPTION
## Summary
- show login screen if not authenticated when the app loads
- add a `/login` route to handle login navigation
- check sign-in result for social logins and revalidate session
- disable social buttons while a login request is in progress
- allow disabling social button when busy

## Testing
- `./flutter/bin/flutter analyze` *(fails: The Flutter directory is not a clone of the GitHub project)*
- `./flutter/bin/flutter test` *(fails: The Flutter directory is not a clone of the GitHub project)*

------
https://chatgpt.com/codex/tasks/task_e_687c9a5ad1b88331b3d0eba1054482a8