### PR TITLE
Add feedback replay controls and bypass button

### DIFF
--- a/lib/screens/exercise_preview_screen.dart
+++ b/lib/screens/exercise_preview_screen.dart
@@ -1,5 +1,6 @@
 // lib/screens/exercise_preview_screen.dart
 // ─────────────────────────────────────────────────────────────────────────────
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -34,14 +35,14 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen> {
   final _picker   = ImagePicker();
 
   /* ───────────── progress helper ───────────── */
-  Future<void> _showProcessingDialog() async {
+  Future<void> _showProcessingDialog(VoidCallback onSkip) async {
     debugPrint('[ExercisePreview] showing “Analyzing…” dialog');
     await showDialog(
       context: context,
       barrierDismissible: false,
       useRootNavigator: false,
-      builder: (_) => const AlertDialog(
-        content: Row(
+      builder: (_) => AlertDialog(
+        content: const Row(
           children: [
             SizedBox(
               width: 28,
@@ -52,6 +53,12 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen> {
             Expanded(child: Text('Analyzing your video…')),
           ],
         ),
+        actions: [
+          TextButton(
+            onPressed: onSkip,
+            child: const Text('Show replay'),
+          ),
+        ],
       ),
     );
   }
@@ -110,21 +117,33 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen> {
 
     /* D. 🔄  polling for report ───────────────────────────────────── */
     try {
-      _showProcessingDialog();                       // fire-and-forget
+      final skipCompleter = Completer<Map<String, dynamic>>();
+      _showProcessingDialog(() {
+        _hideProcessingDialog();
+        if (!skipCompleter.isCompleted) skipCompleter.complete({});
+      });
 
-      final report = await ApiClient.fetchReport(
-        s3Path,
-        delay: const Duration(seconds: 6),
-        max: 120,
-      );
+      final report = await Future.any([
+        ApiClient.fetchReport(
+          s3Path,
+          delay: const Duration(seconds: 6),
+          max: 120,
+        ),
+        skipCompleter.future,
+      ]);
 
       _hideProcessingDialog();
-      debugPrint('✅ report downloaded for $s3Path');
 
-      _navigateToFeedback(localPath, s3Path, report);
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('🎉 Analysis finished')),
-      );
+      if (skipCompleter.isCompleted) {
+        debugPrint('[ExercisePreview] bypassing processing – showing replay');
+        _navigateToFeedback(localPath, s3Path, {});
+      } else {
+        debugPrint('✅ report downloaded for $s3Path');
+        _navigateToFeedback(localPath, s3Path, report);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('🎉 Analysis finished')),
+        );
+      }
     } catch (e) {
       _hideProcessingDialog();
       debugPrint('[ExercisePreview] fetchReport failed → $e');

--- a/lib/screens/feedback_screen.dart
+++ b/lib/screens/feedback_screen.dart
@@ -188,6 +188,31 @@ class _FeedbackScreenState extends State<FeedbackScreen> {
     );
   }
 
+  /* ────────────── seek helpers ───────────── */
+
+  Duration _durationForFrame(int frame) =>
+      Duration(milliseconds: (frame / _assumedFps * 1000).round());
+
+  void _seekPrevMistake() {
+    if (_events.isEmpty) return;
+    final curFrame = (_vc.value.position.inMilliseconds / 1000.0 * _assumedFps).round();
+    final prev = _events.lastWhere(
+      (e) => e.frame < curFrame,
+      orElse: () => _events.first,
+    );
+    _vc.seekTo(_durationForFrame(prev.frame));
+  }
+
+  void _seekNextMistake() {
+    if (_events.isEmpty) return;
+    final curFrame = (_vc.value.position.inMilliseconds / 1000.0 * _assumedFps).round();
+    final next = _events.firstWhere(
+      (e) => e.frame > curFrame,
+      orElse: () => _events.last,
+    );
+    _vc.seekTo(_durationForFrame(next.frame));
+  }
+
   /* ───────────────────────────── UI ───────────────────────────── */
 
   @override
@@ -244,6 +269,11 @@ class _FeedbackScreenState extends State<FeedbackScreen> {
               child: Row(
                 children: [
                   IconButton(
+                    tooltip: 'Previous mistake',
+                    icon: const Icon(Icons.skip_previous),
+                    onPressed: _seekPrevMistake,
+                  ),
+                  IconButton(
                     iconSize: 32,
                     icon: Icon(
                       _vc.value.isPlaying
@@ -267,6 +297,12 @@ class _FeedbackScreenState extends State<FeedbackScreen> {
                       ),
                     ),
                   ),
+                  IconButton(
+                    tooltip: 'Next mistake',
+                    icon: const Icon(Icons.skip_next),
+                    onPressed: _seekNextMistake,
+                  ),
+                  const SizedBox(width: 4),
                   Text(
                     '${_fmt(position)} / ${_fmt(duration)}',
                     style: Theme.of(context).textTheme.labelSmall,


### PR DESCRIPTION
## Summary
- add skip button to analysis dialog to jump directly to replay
- add prev/next mistake controls to feedback playback

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689853404d50833199c8162f6aa938ce