### PR TITLE
Add debug logging for pose matching diagnostics

### DIFF
--- a/lib/screens/exercise_preview_screen.dart
+++ b/lib/screens/exercise_preview_screen.dart
@@ -129,7 +129,8 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
       _refReady = _matcher.refPoints != null;
       if (kDebugMode) {
         debugPrint('[ExercisePreview] reference loaded: $_refReady '
-            '(kpts=${_matcher.refPoints?.length ?? 0})');
+            '(kpts=${_matcher.refPoints?.length ?? 0}, '
+            'source=${_matcher.refSource ?? 'unknown'})');
       }
     } catch (e) {
       if (kDebugMode) debugPrint('[ExercisePreview] ensureLoaded error: $e');
@@ -282,6 +283,13 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
     final mae = _matcher.compareMAEPx(pts);
     _lastMaePx = mae;
     bool ok = _matcher.isMatchByMAE(mae);
+
+    if (kDebugMode) {
+      final refSrc = _matcher.refSource ?? 'unknown';
+      final maeLabel = mae.isFinite ? mae.toStringAsFixed(2) : mae.toString();
+      debugPrint('[PoseMatch] maePx=$maeLabel, match=$ok, '
+          'reference=$refSrc, liveSpace=${w}x$h (raw camera)');
+    }
 
     // 2) Optional sanity checks (each gated by a 0/1 flag from this screen)
     if (ok && (

--- a/lib/shared/services/live_pose.dart
+++ b/lib/shared/services/live_pose.dart
@@ -24,6 +24,7 @@ class LivePoseEngine {
   _Det? _roi;              // last person box in raw coords
   _LetterboxMeta? _lb;     // last letterbox info to map 640→raw
   bool _printedRtmShapes = false; // one-time debug print
+  bool _reportedOutputSpace = false; // one-time keypoint space log
 
   Future<void> _ensureModelsLoaded() async {
     _yolo ??= await OrtManager.fromAsset('assets/models/yolov8n.onnx');
@@ -80,6 +81,12 @@ class LivePoseEngine {
       final yRaw = (k[1] - lb.meta.padY) / lb.meta.scale;
       return Offset(xRaw, yRaw);
     }).toList(growable: false);
+
+    if (kDebugMode && !_reportedOutputSpace) {
+      debugPrint('[LivePoseEngine] Keypoints decoded from RTM crop 256x192, '
+          'YOLO letterbox 640x640 → returning raw-space ${cam.width}x${cam.height} offsets');
+      _reportedOutputSpace = true;
+    }
 
     _frameIdx++;
     return ptsRaw;


### PR DESCRIPTION
## Summary
- log the reference pose source when loading assets
- emit detailed pose matching debug output with MAE and live keypoint space
- document the RTM crop and output space when decoding live keypoints

## Testing
- flutter analyze *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d8e3836048832f82a91e3f21c0e20b