### PR TITLE
Fix reference skeleton alignment

### DIFF
--- a/lib/screens/exercise_preview_screen.dart
+++ b/lib/screens/exercise_preview_screen.dart
@@ -82,7 +82,8 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
   List<Offset>? _latestPts;
   Size? _latestImgSize;
   bool _showLiveSkeleton = true; // toggled via the AppBar eye icon
-  List<Offset>? _refOverlayPts;  // reference skeleton projected into live frame
+  List<Offset>? _refOverlayPts;  // reference skeleton shown in overlay (fixed)
+  List<Offset>? _refFixedPts;    // same reference used for MAE comparisons
   StreamSubscription<AccelerometerEvent>? _accelSub;
 
   // Tilt range caps
@@ -228,21 +229,20 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
           _latestImgSize = Size(img.width.toDouble(), img.height.toDouble());
 
           if (_matcher.refPoints != null) {
-            // Try aligning reference → live; if that fails, show centered ref as fallback.
-            final aligned = _matcher.referenceAlignedToLive(pts);
-            if (aligned != null) {
-              _refOverlayPts = aligned;
-              _refReady = true;
-            } else {
-              // Fallback centered display so user still *sees* the reference
-              _refOverlayPts =
-                  _matcher.centeredRefForFrame(_latestImgSize!, heightFrac: 0.70);
-            }
+            // Always display (and compare against) a fixed, centered reference pose.
+            _refOverlayPts =
+                _matcher.centeredRefForFrame(_latestImgSize!, heightFrac: 0.70);
+            _refFixedPts = _refOverlayPts;
+            _refReady = _refOverlayPts != null;
           } else {
             _refOverlayPts = null;
+            _refFixedPts = null;
+            _refReady = false;
           }
         } else {
           _refOverlayPts = null; // avoid showing stale reference
+          _refFixedPts = null;
+          _refReady = false;
         }
         setState(() {}); // repaint overlay
       }
@@ -280,7 +280,12 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
     }
 
     // 1) Primary: reference-skeleton MAE in pixels
-    final mae = _matcher.compareMAEPx(pts);
+    // Ensure we have a centered reference in the same camera space.
+    _refFixedPts ??=
+        _matcher.centeredRefForFrame(Size(w.toDouble(), h.toDouble()), heightFrac: 0.70);
+    final mae = (_refFixedPts != null)
+        ? _matcher.compareMAEPxAgainst(pts, _refFixedPts!)
+        : double.infinity;
     _lastMaePx = mae;
     bool ok = _matcher.isMatchByMAE(mae);
 

--- a/lib/shared/services/pose_matcher.dart
+++ b/lib/shared/services/pose_matcher.dart
@@ -143,6 +143,25 @@ class PoseMatcher {
     return count > 0 ? (sum / count) : double.infinity;
   }
 
+  /// Returns MAE in pixels between live keypoints and a pre-positioned reference
+  /// that is already expressed in the same coordinate space.
+  double compareMAEPxAgainst(List<Offset> live17, List<Offset> reference17) {
+    if (live17.length < 17 || reference17.length < 17) return double.infinity;
+
+    double sum = 0.0;
+    int count = 0;
+    for (int i = 0; i < 17; i++) {
+      final dx = (reference17[i].dx - live17[i].dx).abs();
+      final dy = (reference17[i].dy - live17[i].dy).abs();
+      final d = math.sqrt(dx * dx + dy * dy);
+      if (d.isFinite) {
+        sum += d;
+        count++;
+      }
+    }
+    return count > 0 ? (sum / count) : double.infinity;
+  }
+
   /// Decide match using MAE + thresholds.
   bool isMatchByMAE(double maePx) {
     if (!maePx.isFinite) return false;


### PR DESCRIPTION
## Summary
- keep the reference skeleton fixed at the center of the preview overlay
- compute pose matching scores against the centered reference instead of an aligned copy
- add a matcher helper for comparing live keypoints with a pre-positioned reference

## Testing
- Not run (dart command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68d8e6b509dc832fab4e9a8b47b2978a