### PR TITLE
Add automated 3D pose processing pipeline after recording

### DIFF
--- a/lib/screens/exercise_preview_screen.dart
+++ b/lib/screens/exercise_preview_screen.dart
@@ -29,9 +29,11 @@ import '../shared/services/api_client.dart';
 import '../shared/services/live_pose.dart'; // LIVE RTM-Pose 2D
 import '../shared/services/pose_matcher.dart';
 import '../shared/services/pose_runtime.dart'; // offline pipeline
+import '../shared/services/pose_processing_controller.dart';
 import '../shared/services/s3_uploader.dart';
 import '../shared/services/video_transcoder.dart'; // 10fps helper
 import '../shared/widgets/live_skeleton_overlay.dart';
+import '../shared/widgets/processing_banner.dart';
 
 class ExercisePreviewScreen extends StatefulWidget {
   const ExercisePreviewScreen({super.key, required this.exerciseId});
@@ -68,6 +70,10 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
   double? _lastMaePx; // for debug/toast
   File? _lastVideo; // last recorded or picked video
   XFile? _pendingRecording; // temp holder for safely-stopped recordings
+  late final PoseProcessingController _processingController;
+  StreamSubscription<ProgressEvent>? _processingSub;
+  ProgressEvent? _progressEvent;
+  DateTime? _recordingStartedAt;
 
   /* ───────────── live 2D pose state ───────────── */
   final LivePoseEngine _engine = LivePoseEngine(yoloEvery: 5, roiMargin: 1.25);
@@ -114,6 +120,23 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
   @override
   void initState() {
     super.initState();
+    _processingController = PoseProcessingController();
+    _processingSub = _processingController.progressStream.listen((event) {
+      if (!mounted) return;
+      setState(() {
+        _progressEvent = event;
+      });
+      if (event.status == ProgressStatus.complete ||
+          event.status == ProgressStatus.error ||
+          event.status == ProgressStatus.cancelled) {
+        Future.delayed(const Duration(seconds: 1), () {
+          if (!mounted) return;
+          if (_progressEvent == event) {
+            setState(() => _progressEvent = null);
+          }
+        });
+      }
+    });
     _glowCtrl = AnimationController(
       vsync: this,
       lowerBound: 0.35,
@@ -494,7 +517,7 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
     return xFile == null ? null : File(xFile.path);
   }
 
-  Future<void> _rememberVideo(File videoFile) async {
+  Future<File> _rememberVideo(File videoFile) async {
     try {
       final dir = await getApplicationDocumentsDirectory();
       final ts = DateFormat('yyyy-MM-dd_HH-mm-ss').format(DateTime.now());
@@ -506,8 +529,10 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
           SnackBar(content: Text('Video ready • ${saved.path.split('/').last}')),
         );
       }
+      return saved;
     } catch (_) {
       setState(() => _lastVideo = videoFile); // fall back
+      return videoFile;
     }
   }
 
@@ -773,6 +798,8 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
     _stopRecordingSafely();
     _logPoseEvents = false;
     _cam.dispose();
+    _processingSub?.cancel();
+    unawaited(_processingController.dispose());
     super.dispose();
   }
 
@@ -842,63 +869,65 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
             ),
           ],
         ),
-        body: _recording
-            ? Stack(
-                fit: StackFit.expand,
-                children: [
-                  _buildCameraContent(context, fullscreen: true),
-                  SafeArea(
-                    child: Align(
-                      alignment: Alignment.bottomCenter,
-                      child: Padding(
-                        padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
-                        child: _GradientButton(
-                          height: 56,
-                          onPressed: _toggleRecording,
-                          colors: const [Color(0xFFD32F2F), Color(0xFFE53935)],
-                          icon: Icons.stop,
-                          label: 'Stop recording',
+        body: _withProcessingOverlay(
+          _recording
+              ? Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    _buildCameraContent(context, fullscreen: true),
+                    SafeArea(
+                      child: Align(
+                        alignment: Alignment.bottomCenter,
+                        child: Padding(
+                          padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
+                          child: _GradientButton(
+                            height: 56,
+                            onPressed: _toggleRecording,
+                            colors: const [Color(0xFFD32F2F), Color(0xFFE53935)],
+                            icon: Icons.stop,
+                            label: 'Stop recording',
+                          ),
                         ),
                       ),
                     ),
-                  ),
-                ],
-              )
-            : Column(
-                children: [
-                  Expanded(
-                    child: Padding(
-                      padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
-                      child: ClipRRect(
-                        borderRadius: BorderRadius.circular(28),
-                        clipBehavior: Clip.antiAlias,
-                        child: _buildCameraContent(context, fullscreen: false),
+                  ],
+                )
+              : Column(
+                  children: [
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(28),
+                          clipBehavior: Clip.antiAlias,
+                          child: _buildCameraContent(context, fullscreen: false),
+                        ),
                       ),
                     ),
-                  ),
-                  SafeArea(
-                    top: false,
-                    child: Padding(
-                      padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
-                      child: _ActionPanel(
-                        recording: _recording,
-                        hasVideo: _lastVideo != null,
-                        onToggleRecord: _ready ? _toggleRecording : null,
-                        onPickVideo: () async {
-                          final file = await pickVideoFromGallery();
-                          if (file == null) return;
-                          await _rememberVideo(file);
-                        },
-                        onAnalyze: _analyzeOffline,
-                        onAnalyzeCloud: () async {
-                          final f = _lastVideo;
-                          if (f != null) await _uploadAndProcess(f);
-                        },
+                    SafeArea(
+                      top: false,
+                      child: Padding(
+                        padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+                        child: _ActionPanel(
+                          recording: _recording,
+                          hasVideo: _lastVideo != null,
+                          onToggleRecord: _ready ? _toggleRecording : null,
+                          onPickVideo: () async {
+                            final file = await pickVideoFromGallery();
+                            if (file == null) return;
+                            await _rememberVideo(file);
+                          },
+                          onAnalyze: _analyzeOffline,
+                          onAnalyzeCloud: () async {
+                            final f = _lastVideo;
+                            if (f != null) await _uploadAndProcess(f);
+                          },
+                        ),
                       ),
                     ),
-                  ),
-                ],
-              ),
+                  ],
+                ),
+        ),
       ),
     );
   }
@@ -1081,6 +1110,7 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
     if (_recording) {
       // Stop recording → resume live stream
       _pendingRecording = null;
+      final endTime = DateTime.now();
       await _stopRecordingSafely();
       await Future.delayed(const Duration(milliseconds: 50)); // let native drain
       setState(() => _recording = false);
@@ -1088,13 +1118,15 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
       final xFile = _pendingRecording;
       _pendingRecording = null;
       if (xFile != null) {
-        await _rememberVideo(File(xFile.path));
+        final saved = await _rememberVideo(File(xFile.path));
+        await _runPostRecordingPipeline(saved, endTime: endTime);
       }
       if (!_cam.value.isStreamingImages) {
         await Future.delayed(const Duration(milliseconds: 50));
         await _setStreaming(true);
       }
       HapticFeedback.selectionClick();
+      _recordingStartedAt = null;
     } else {
       // Start recording → stop live stream (Camera cannot do both)
       if (_cam.value.isStreamingImages) {
@@ -1106,8 +1138,121 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
       await _cam.startVideoRecording();
       setState(() => _recording = true);
       _logPoseEvents = true;
+      _recordingStartedAt = DateTime.now();
       HapticFeedback.heavyImpact();
     }
+  }
+
+  Future<void> _runPostRecordingPipeline(
+    File videoFile, {
+    required DateTime endTime,
+  }) async {
+    if (_processingController.isProcessing) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Processing already in progress…')),
+        );
+      }
+      return;
+    }
+
+    final startTime = _recordingStartedAt ?? endTime;
+    final preview = _cam.value.previewSize;
+    final width = preview == null ? 0 : preview.height.toInt();
+    final height = preview == null ? 0 : preview.width.toInt();
+
+    final meta = VideoMeta(
+      sessionId: generateSessionId(),
+      fps: 10.0,
+      width: width,
+      height: height,
+      exercise: widget.exerciseId,
+      startTime: startTime,
+      endTime: endTime,
+      platform: Platform.isIOS ? 'ios' : 'android',
+      appVersion: 'dev-build',
+    );
+
+    try {
+      final outcome = await _processingController.processRecording(
+        videoFile: videoFile,
+        meta: meta,
+      );
+      final report = outcome.toFeedbackReport();
+      if (!mounted) return;
+      await _navigateToFeedback(
+        videoFile.path,
+        'local/${widget.exerciseId}/${outcome.sessionId}.mp4',
+        report,
+      );
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('🎯 3D pose analysis ready!')),
+      );
+    } on PoseProcessingCancelled {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('3D processing cancelled.')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('3D analysis failed: $e')),
+      );
+    }
+  }
+
+  Future<void> _confirmCancelProcessing() async {
+    if (!_processingController.isProcessing) return;
+    final confirm = await showDialog<bool>(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            title: const Text('Cancel processing?'),
+            content: const Text(
+                'This will discard all pose data captured for this session.'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(ctx).pop(false),
+                child: const Text('Keep processing'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(ctx).pop(true),
+                child: const Text('Cancel'),
+              ),
+            ],
+          ),
+        ) ??
+        false;
+    if (confirm) {
+      _processingController.cancel();
+    }
+  }
+
+  Widget _withProcessingOverlay(Widget child) {
+    final event = _progressEvent;
+    if (event == null || event.isHidden) {
+      return child;
+    }
+    final allowCancel = event.status == ProgressStatus.indeterminate ||
+        event.status == ProgressStatus.determinate;
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        child,
+        SafeArea(
+          child: Align(
+            alignment: Alignment.topCenter,
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: ProcessingBanner(
+                event: event,
+                onCancel: allowCancel ? _confirmCancelProcessing : null,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
   }
 
   // POST { "s3_key": "<path>", … } to Flask /enqueue

--- a/lib/shared/services/pose_processing_controller.dart
+++ b/lib/shared/services/pose_processing_controller.dart
@@ -1,0 +1,384 @@
+// lib/shared/services/pose_processing_controller.dart
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import 'pose_runtime.dart';
+
+typedef SessionId = String;
+
+class VideoMeta {
+  VideoMeta({
+    required this.sessionId,
+    required this.fps,
+    required this.width,
+    required this.height,
+    required this.exercise,
+    required this.startTime,
+    required this.endTime,
+    required this.platform,
+    required this.appVersion,
+  });
+
+  final SessionId sessionId;
+  final double fps;
+  final int width;
+  final int height;
+  final String exercise;
+  final DateTime startTime;
+  final DateTime endTime;
+  final String platform;
+  final String appVersion;
+}
+
+enum ProgressStatus { hidden, indeterminate, determinate, complete, error, cancelled }
+
+class ProgressEvent {
+  ProgressEvent._({
+    required this.status,
+    this.phase,
+    this.value,
+    this.processed,
+    this.total,
+    this.message,
+    this.allowCancel = true,
+  });
+
+  final ProgressStatus status;
+  final String? phase;
+  final double? value;
+  final int? processed;
+  final int? total;
+  final String? message;
+  final bool allowCancel;
+
+  bool get isHidden => status == ProgressStatus.hidden;
+
+  factory ProgressEvent.hidden() =>
+      ProgressEvent._(status: ProgressStatus.hidden, allowCancel: false);
+
+  factory ProgressEvent.indeterminate({required String phase, bool allowCancel = true}) =>
+      ProgressEvent._(status: ProgressStatus.indeterminate, phase: phase, allowCancel: allowCancel);
+
+  factory ProgressEvent.determinate({
+    required String phase,
+    required double value,
+    int? processed,
+    int? total,
+    bool allowCancel = true,
+  }) =>
+      ProgressEvent._(
+        status: ProgressStatus.determinate,
+        phase: phase,
+        value: value,
+        processed: processed,
+        total: total,
+        allowCancel: allowCancel,
+      );
+
+  factory ProgressEvent.complete({String phase = 'Completed'}) =>
+      ProgressEvent._(status: ProgressStatus.complete, phase: phase, allowCancel: false, value: 1.0);
+
+  factory ProgressEvent.error(String message) => ProgressEvent._(
+        status: ProgressStatus.error,
+        phase: 'Error',
+        message: message,
+        allowCancel: false,
+      );
+
+  factory ProgressEvent.cancelled() => ProgressEvent._(
+        status: ProgressStatus.cancelled,
+        phase: 'Cancelled',
+        allowCancel: false,
+      );
+}
+
+class PoseProcessingOutcome {
+  PoseProcessingOutcome({
+    required this.sessionId,
+    required this.sessionDir,
+    required this.sequence2d,
+    required this.result3d,
+    required this.summary2d,
+    required this.summary3d,
+  });
+
+  final SessionId sessionId;
+  final Directory sessionDir;
+  final Pose2DSequence sequence2d;
+  final Pose3DResult result3d;
+  final Map<String, dynamic> summary2d;
+  final Map<String, dynamic> summary3d;
+
+  Map<String, dynamic> toFeedbackReport() => {
+        'num_frames': sequence2d.frames.length,
+        'num_joints': 17,
+        'kpts2d': sequence2d.frames.map((f) => f.toRawList()).toList(),
+        'kpts3d': result3d.sequence,
+        'meta': {
+          'fps': sequence2d.fps,
+          'window': result3d.windowSize,
+          'stride': result3d.stride,
+        },
+      };
+}
+
+class PoseProcessingCancelled implements Exception {
+  const PoseProcessingCancelled();
+}
+
+class PoseProcessingController {
+  PoseProcessingController({PosePipeline? pipeline}) : _pipeline = pipeline ?? PosePipeline();
+
+  final PosePipeline _pipeline;
+  final _progressCtrl = StreamController<ProgressEvent>.broadcast();
+  bool _processing = false;
+  bool _cancelRequested = false;
+
+  Stream<ProgressEvent> get progressStream => _progressCtrl.stream;
+  bool get isProcessing => _processing;
+
+  Future<PoseProcessingOutcome> processRecording({
+    required File videoFile,
+    required VideoMeta meta,
+  }) async {
+    if (_processing) {
+      throw StateError('Processing already in progress');
+    }
+
+    _processing = true;
+    _cancelRequested = false;
+
+    Directory? sessionDir;
+
+    try {
+      sessionDir = await _prepareSessionDir(meta.sessionId);
+      final dir2d = Directory(p.join(sessionDir.path, '2d'))..createSync(recursive: true);
+      final dir3d = Directory(p.join(sessionDir.path, '3d'))..createSync(recursive: true);
+
+      _progressCtrl.add(ProgressEvent.indeterminate(phase: 'Finalizing 2D frames'));
+      final seq2d = await _pipeline.extract2D(
+        videoFile,
+        targetFps: meta.fps,
+        shouldAbort: () => _cancelRequested,
+      );
+
+      if (_cancelRequested) {
+        throw const PoseProcessingCancelled();
+      }
+
+      await _write2D(dir2d, seq2d);
+      final summary2d = _build2DIndex(seq2d, meta);
+
+      _progressCtrl.add(ProgressEvent.indeterminate(phase: 'Preparing 3D input'));
+
+      final result3d = await _pipeline.estimate3D(
+        seq2d,
+        onProgress: (progress) {
+          if (_cancelRequested) return;
+          if (progress.phase == PosePipelinePhase.running3d) {
+            _progressCtrl.add(
+              ProgressEvent.determinate(
+                phase: 'Estimating 3D poses',
+                value: progress.fraction,
+                processed: progress.processed,
+                total: progress.total,
+              ),
+            );
+          }
+        },
+        shouldAbort: () => _cancelRequested,
+      );
+
+      if (_cancelRequested) {
+        throw const PoseProcessingCancelled();
+      }
+
+      await _write3D(dir3d, result3d);
+      final summary3d = _build3DIndex(result3d);
+
+      await _writeMeta(sessionDir, meta, summary2d, summary3d);
+
+      _progressCtrl.add(ProgressEvent.complete(phase: '3D analysis complete'));
+
+      return PoseProcessingOutcome(
+        sessionId: meta.sessionId,
+        sessionDir: sessionDir,
+        sequence2d: seq2d,
+        result3d: result3d,
+        summary2d: summary2d,
+        summary3d: summary3d,
+      );
+    } on PoseProcessingCancelled {
+      if (sessionDir != null) {
+        await _deleteDir(sessionDir);
+      }
+      _progressCtrl.add(ProgressEvent.cancelled());
+      throw const PoseProcessingCancelled();
+    } on PosePipelineCancelled {
+      if (sessionDir != null) {
+        await _deleteDir(sessionDir);
+      }
+      _progressCtrl.add(ProgressEvent.cancelled());
+      throw const PoseProcessingCancelled();
+    } catch (e, st) {
+      if (sessionDir != null) {
+        await _deleteDir(sessionDir);
+      }
+      if (kDebugMode) {
+        debugPrint('Pose processing failed: $e\n$st');
+      }
+      _progressCtrl.add(ProgressEvent.error(e.toString()));
+      rethrow;
+    } finally {
+      _processing = false;
+      _cancelRequested = false;
+    }
+  }
+
+  void cancel() {
+    if (!_processing) return;
+    _cancelRequested = true;
+  }
+
+  Future<void> dispose() async {
+    await _progressCtrl.close();
+  }
+
+  Future<Directory> _prepareSessionDir(SessionId sessionId) async {
+    final base = await _baseDir();
+    final sessionDir = Directory(p.join(base.path, 'poses', sessionId));
+    if (sessionDir.existsSync()) {
+      await sessionDir.delete(recursive: true);
+    }
+    await sessionDir.create(recursive: true);
+    return sessionDir;
+  }
+
+  Future<Directory> _baseDir() async {
+    final docs = await getApplicationDocumentsDirectory();
+    final base = Directory(p.join(docs.path, 'FitPerfect'));
+    if (!base.existsSync()) {
+      await base.create(recursive: true);
+    }
+    return base;
+  }
+
+  Future<void> _write2D(Directory dir, Pose2DSequence seq) async {
+    final framesPath = File(p.join(dir.path, 'frames.jsonl'));
+    final tmp = File('${framesPath.path}.tmp');
+    final sink = tmp.openWrite();
+    for (final frame in seq.frames) {
+      sink.writeln(jsonEncode(frame.toJson()));
+    }
+    await sink.flush();
+    await sink.close();
+    await tmp.rename(framesPath.path);
+
+    final index = _build2DIndex(seq, null);
+    await _writeJsonAtomic(File(p.join(dir.path, 'index.json')), index);
+  }
+
+  Future<void> _write3D(Directory dir, Pose3DResult result) async {
+    final windowsPath = File(p.join(dir.path, 'windows.jsonl'));
+    final tmp = File('${windowsPath.path}.tmp');
+    final sink = tmp.openWrite();
+    for (final window in result.windows) {
+      sink.writeln(jsonEncode(window.toJson()));
+    }
+    await sink.flush();
+    await sink.close();
+    await tmp.rename(windowsPath.path);
+
+    final index = _build3DIndex(result);
+    await _writeJsonAtomic(File(p.join(dir.path, 'index.json')), index);
+  }
+
+  Future<void> _writeMeta(
+    Directory dir,
+    VideoMeta meta,
+    Map<String, dynamic> index2d,
+    Map<String, dynamic> index3d,
+  ) async {
+    final cfg = _pipeline.motionBertConfig;
+    final payload = {
+      'sessionId': meta.sessionId,
+      'appVersion': meta.appVersion,
+      'platform': meta.platform,
+      'fps': meta.fps,
+      'startTime': meta.startTime.toUtc().toIso8601String(),
+      'endTime': meta.endTime.toUtc().toIso8601String(),
+      'exercise': meta.exercise,
+      'model2D': {
+        'name': 'RTM-Pose rtm-m',
+        'keypoints': 'RTM→H36M17',
+        'confidenceMin': null,
+      },
+      'model3D': {
+        'name': 'MotionBERT',
+        'onnxPath': cfg.assetPath,
+        'T': cfg.window,
+      },
+      'schemaVersion': 1,
+      'index2d': index2d,
+      'index3d': index3d,
+    };
+    await _writeJsonAtomic(File(p.join(dir.path, 'meta.json')), payload);
+  }
+
+  Map<String, dynamic> _build2DIndex(Pose2DSequence seq, VideoMeta? meta) {
+    final frames = seq.frames;
+    final timestamps = frames.isEmpty
+        ? const {'start': 0.0, 'end': 0.0}
+        : {
+            'start': double.parse(frames.first.t.toStringAsFixed(3)),
+            'end': double.parse(frames.last.t.toStringAsFixed(3)),
+          };
+    return {
+      'frameCount': frames.length,
+      'fps': seq.fps,
+      'keypointSet': 'H36M-17',
+      'schemaVersion': 1,
+      'timestamps': timestamps,
+      if (meta != null) 'imgW': meta.width,
+      if (meta != null) 'imgH': meta.height,
+    };
+  }
+
+  Map<String, dynamic> _build3DIndex(Pose3DResult result) => {
+        'windowCount': result.windows.length,
+        'skeleton': 'H36M-17',
+        'normalization': 'center-subtract, scale=min(W,H)/2',
+        'schemaVersion': 1,
+        'windowSize': result.windowSize,
+        'stride': result.stride,
+        'pelvisCentered': result.pelvisCentered,
+      };
+
+  Future<void> _writeJsonAtomic(File file, Map<String, dynamic> data) async {
+    final tmp = File('${file.path}.tmp');
+    await tmp.writeAsString(jsonEncode(data));
+    if (await file.exists()) {
+      await file.delete();
+    }
+    await tmp.rename(file.path);
+  }
+
+  Future<void> _deleteDir(Directory dir) async {
+    if (await dir.exists()) {
+      await dir.delete(recursive: true);
+    }
+  }
+}
+
+SessionId generateSessionId() {
+  final now = DateTime.now().toUtc();
+  final base = now.toIso8601String().replaceAll(':', '-').replaceAll('.', '-');
+  final rand = Random().nextInt(0xFFFFFF).toRadixString(16).padLeft(6, '0');
+  return '${base}_$rand';
+}

--- a/lib/shared/services/pose_runtime.dart
+++ b/lib/shared/services/pose_runtime.dart
@@ -2,164 +2,517 @@
 import 'dart:io';
 import 'dart:math' as math;
 import 'dart:typed_data';
+
 import 'package:flutter/foundation.dart';
 import 'package:image/image.dart' as img;
 import 'package:onnxruntime/onnxruntime.dart';
 
 import 'ort_session.dart';
-import 'video_sampler.dart';
 import 'tensor_utils.dart';
+import 'video_sampler.dart';
 
-// lib/shared/services/pose_runtime.dart
-class PosePipelineResult {
-  PosePipelineResult({required this.kpts2d, required this.kpts3d});
-  final List<List<List<double>>> kpts2d; // [T][17][3] (x,y,conf)
-  final List<List<List<double>>> kpts3d; // [T][17][3] (x,y,z)
+/// Callback emitted from the offline pipeline when 3D progress changes.
+typedef PosePipelineProgressCallback = void Function(PosePipelineProgress progress);
 
-  Map<String, dynamic> toReport() => {
-    'num_frames': kpts2d.length,
-    'num_joints': 17,
-    'kpts2d': kpts2d,
-    'kpts3d': kpts3d,
-  };
+enum PosePipelinePhase { preparing3d, running3d }
+
+class PosePipelineProgress {
+  const PosePipelineProgress._(this.phase, this.processed, this.total);
+
+  final PosePipelinePhase phase;
+  final int processed;
+  final int total;
+
+  double get fraction => total == 0 ? 0.0 : processed / total;
+
+  factory PosePipelineProgress.preparing3d() =>
+      const PosePipelineProgress._(PosePipelinePhase.preparing3d, 0, 0);
+
+  factory PosePipelineProgress.running3d({required int processed, required int total}) =>
+      PosePipelineProgress._(PosePipelinePhase.running3d, processed, total);
 }
 
+class PoseKeypoint2D {
+  const PoseKeypoint2D({
+    required this.id,
+    required this.x,
+    required this.y,
+    this.c,
+  });
+
+  final int id;
+  final double x;
+  final double y;
+  final double? c;
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'x': x,
+        'y': y,
+        if (c != null) 'c': c,
+      };
+}
+
+class Pose2DFrame {
+  const Pose2DFrame({
+    required this.frameIndex,
+    required this.t,
+    required this.keypoints,
+    required this.imgW,
+    required this.imgH,
+  });
+
+  final int frameIndex;
+  final double t;
+  final List<PoseKeypoint2D> keypoints;
+  final int imgW;
+  final int imgH;
+
+  Map<String, dynamic> toJson() => {
+        'frameIndex': frameIndex,
+        't': double.parse(t.toStringAsFixed(3)),
+        'keypoints': keypoints.map((k) => k.toJson()).toList(),
+        'imgW': imgW,
+        'imgH': imgH,
+      };
+
+  List<List<double>> toRawList() => keypoints
+      .map((k) => [k.x, k.y, k.c ?? 0.0])
+      .toList(growable: false);
+}
+
+class Pose2DSequence {
+  const Pose2DSequence({
+    required this.frames,
+    required this.fps,
+    required this.imageWidth,
+    required this.imageHeight,
+  });
+
+  final List<Pose2DFrame> frames;
+  final double fps;
+  final int imageWidth;
+  final int imageHeight;
+
+  bool get isEmpty => frames.isEmpty;
+}
+
+class Pose3DWindow {
+  const Pose3DWindow({
+    required this.windowIndex,
+    required this.frameStart,
+    required this.stride,
+    required this.T,
+    required this.joints3D,
+    required this.units,
+    required this.rootJoint,
+    required this.pelvisCentered,
+    required this.notes,
+  });
+
+  final int windowIndex;
+  final int frameStart;
+  final int stride;
+  final int T;
+  final List<List<List<double>>> joints3D;
+  final String units;
+  final String rootJoint;
+  final bool pelvisCentered;
+  final String notes;
+
+  Map<String, dynamic> toJson() => {
+        'windowIndex': windowIndex,
+        'frameStart': frameStart,
+        'stride': stride,
+        'T': T,
+        'joints3D': joints3D,
+        'units': units,
+        'rootJoint': rootJoint,
+        'pelvisCentered': pelvisCentered,
+        'notes': notes,
+      };
+}
+
+class Pose3DResult {
+  const Pose3DResult({
+    required this.windows,
+    required this.sequence,
+    required this.windowSize,
+    required this.stride,
+    required this.pelvisCentered,
+  });
+
+  final List<Pose3DWindow> windows;
+  final List<List<List<double>>> sequence; // [T][17][3]
+  final int windowSize;
+  final int stride;
+  final bool pelvisCentered;
+}
+
+class PosePipelineResult {
+  const PosePipelineResult({required this.pose2d, required this.pose3d});
+
+  final Pose2DSequence pose2d;
+  final Pose3DResult pose3d;
+
+  Map<String, dynamic> toReport() => {
+        'num_frames': pose2d.frames.length,
+        'num_joints': 17,
+        'kpts2d': pose2d.frames.map((f) => f.toRawList()).toList(),
+        'kpts3d': pose3d.sequence,
+        'meta': {
+          'fps': pose2d.fps,
+          'window': pose3d.windowSize,
+          'stride': pose3d.stride,
+        }
+      };
+}
+
+class MotionBertConfig {
+  const MotionBertConfig({
+    required this.assetPath,
+    required this.window,
+    required this.stride,
+  });
+
+  final String assetPath;
+  final int window;
+  final int stride;
+}
+
+class PosePipelineCancelled implements Exception {}
 
 class PosePipeline {
   OrtSession? _yolo;
   OrtSession? _rtm;
   OrtSession? _mb;
+  MotionBertConfig? _mbConfig;
 
-  Future<void> _ensureModelsLoaded() async {
+  Future<void> _ensure2DModelsLoaded() async {
     _yolo ??= await OrtManager.fromAsset('assets/models/yolov8n.onnx');
-    _rtm  ??= await OrtManager.fromAsset('assets/models/rtmpose-m_256x192.onnx');
-    _mb   ??= await OrtManager.fromAsset('assets/models/motionbert_lite_81.onnx');
+    _rtm ??= await OrtManager.fromAsset('assets/models/rtmpose-m_256x192.onnx');
   }
 
-  Future<PosePipelineResult> analyzeVideo(File video, {int mbWindow = 81}) async {
-    await _ensureModelsLoaded();
+  Future<void> _ensureMotionBertLoaded() async {
+    if (_mb != null) return;
+    final configs = [
+      const MotionBertConfig(
+        assetPath: 'assets/models/motionbert_3d_243.onnx',
+        window: 243,
+        stride: 81,
+      ),
+      const MotionBertConfig(
+        assetPath: 'assets/models/motionbert_lite_81.onnx',
+        window: 81,
+        stride: 27,
+      ),
+    ];
+
+    for (final cfg in configs) {
+      try {
+        final session = await OrtManager.fromAsset(cfg.assetPath);
+        _mb = session;
+        _mbConfig = cfg;
+        break;
+      } catch (e) {
+        if (kDebugMode) {
+          debugPrint('[PosePipeline] Could not load ${cfg.assetPath}: $e');
+        }
+        continue;
+      }
+    }
+
+    if (_mb == null || _mbConfig == null) {
+      throw Exception('MotionBERT model not found. Provide motionbert_3d_243.onnx or motionbert_lite_81.onnx.');
+    }
+  }
+
+  MotionBertConfig get motionBertConfig {
+    final cfg = _mbConfig;
+    if (cfg == null) {
+      throw StateError('MotionBERT not initialized yet');
+    }
+    return cfg;
+  }
+
+  Future<PosePipelineResult> analyzeVideo(
+    File video, {
+    PosePipelineProgressCallback? onProgress,
+    bool Function()? shouldAbort,
+  }) async {
+    final seq = await extract2D(
+      video,
+      shouldAbort: shouldAbort,
+    );
+    final res3d = await estimate3D(
+      seq,
+      onProgress: onProgress,
+      shouldAbort: shouldAbort,
+    );
+    return PosePipelineResult(pose2d: seq, pose3d: res3d);
+  }
+
+  Future<Pose2DSequence> extract2D(
+    File video, {
+    double targetFps = 10.0,
+    bool Function()? shouldAbort,
+  }) async {
+    await _ensure2DModelsLoaded();
 
     final frames = await VideoSampler.extract10FpsJpgs(video);
+    final results = <Pose2DFrame>[];
 
-    final all2D = <List<List<double>>>[];
-    for (final f in frames) {
-      final jpg = await f.readAsBytes();
+    for (int i = 0; i < frames.length; i++) {
+      if (shouldAbort?.call() == true) throw PosePipelineCancelled();
 
-      final yoloIn  = _prepYolo(jpg);                   // (1,3,640,640)
-      final yoloOut = await _run(_yolo!, {'images': yoloIn});
-      final det     = _pickBestPerson(yoloOut.first!);  // may be null
-
-      if (det == null) {
-        all2D.add(List.generate(17, (_) => [0.0, 0.0, 0.0]));
+      final file = frames[i];
+      final jpg = await file.readAsBytes();
+      final image = img.decodeImage(jpg);
+      if (image == null) {
+        results.add(_emptyFrame(i, targetFps));
         continue;
       }
 
-      final crop = _cropForRtm(jpg, det, outH: 256, outW: 192);
-      final rtmIn   = _prepRtm(crop.image);                 // (1,3,256,192)
-      final rtmOuts = await _run(_rtm!, {'input': rtmIn});
-      if (kDebugMode && all2D.isEmpty) {
-        debugPrint('RTM outputs shapes (offline): '
-            '${_shapeOf(rtmOuts.isNotEmpty ? rtmOuts[0]?.value : null)}'
-            '${rtmOuts.length > 1 ? ' & ${_shapeOf(rtmOuts[1]?.value)}' : ''}');
-      }
-      final kpts = _decodeAuto(rtmOuts, crop.meta);
+      final yoloIn = _prepYolo(image);
+      final yoloOuts = await _run(_yolo!, {'images': yoloIn});
+      final det = yoloOuts.isEmpty ? null : _pickBestPerson(yoloOuts.first!);
 
-      all2D.add(kpts);
+      List<List<double>> h36m;
+      if (det == null) {
+        h36m = List.generate(17, (_) => [0.0, 0.0, 0.0]);
+      } else {
+        final crop = _cropForRtm(jpg, det, outH: 256, outW: 192);
+        final rtmIn = _prepRtm(crop.image);
+        final rtmOuts = await _run(_rtm!, {'input': rtmIn});
+        final raw = _decodeAuto(rtmOuts, crop.meta);
+        h36m = _remapToH36M(raw);
+      }
+
+      final frame = Pose2DFrame(
+        frameIndex: i,
+        t: i / targetFps,
+        imgW: image.width,
+        imgH: image.height,
+        keypoints: List.generate(17, (j) {
+          final kp = h36m[j];
+          return PoseKeypoint2D(
+            id: j,
+            x: kp[0],
+            y: kp[1],
+            c: kp.length > 2 ? kp[2] : null,
+          );
+        }),
+      );
+      results.add(frame);
     }
 
-    final T = math.min(mbWindow, all2D.length);
-    final mbIn   = _toMbInput(all2D.take(T).toList());               // [1,T,17,3]
-    final mbOuts = await _run(_mb!, {'input': mbIn});
-    final out3d  = _toList4D(mbOuts.first!.value, dims: [1, T, 17, 3])[0]; // ← .value
-
-    return PosePipelineResult(kpts2d: all2D.take(T).toList(), kpts3d: out3d);
+    return Pose2DSequence(
+      frames: results,
+      fps: targetFps,
+      imageWidth: results.isEmpty ? 0 : results.first.imgW,
+      imageHeight: results.isEmpty ? 0 : results.first.imgH,
+    );
   }
 
-  Future<List<OrtValue?>> _run(OrtSession s, Map<String, OrtValue> inputs) async {
+  Future<Pose3DResult> estimate3D(
+    Pose2DSequence seq, {
+    PosePipelineProgressCallback? onProgress,
+    bool pelvisCentered = false,
+    bool Function()? shouldAbort,
+  }) async {
+    await _ensureMotionBertLoaded();
+
+    final frames = seq.frames;
+    if (frames.isEmpty) {
+      return Pose3DResult(
+        windows: const [],
+        sequence: const [],
+        windowSize: motionBertConfig.window,
+        stride: motionBertConfig.stride,
+        pelvisCentered: pelvisCentered,
+      );
+    }
+
+    onProgress?.call(PosePipelineProgress.preparing3d());
+
+    final T = motionBertConfig.window;
+    final stride = motionBertConfig.stride;
+    final starts = _computeWindowStarts(frames.length, T, stride);
+
+    final fused = List.generate(
+      frames.length,
+      (_) => List.generate(17, (_) => List<double>.filled(3, 0.0, growable: false),
+          growable: false),
+      growable: false,
+    );
+    final counts = List.generate(
+      frames.length,
+      (_) => List<int>.filled(17, 0, growable: false),
+      growable: false,
+    );
+
+    final windows = <Pose3DWindow>[];
+    int processed = 0;
+    onProgress?.call(PosePipelineProgress.running3d(processed: processed, total: starts.length));
+
+    for (final start in starts) {
+      if (shouldAbort?.call() == true) throw PosePipelineCancelled();
+
+      final window = _prepareWindow(frames, start, T);
+      final input = _toMotionBertInput(window.frames);
+      final outs = await _run(_mb!, {'input': input});
+      if (outs.isEmpty) {
+        processed++;
+        onProgress?.call(PosePipelineProgress.running3d(processed: processed, total: starts.length));
+        continue;
+      }
+
+      final out = outs.first!;
+      final joints = _toList4D(out.value, dims: [1, T, 17, 3])[0];
+
+      if (pelvisCentered) {
+        for (int t = 0; t < joints.length; t++) {
+          final pelvis = joints[t][0];
+          for (int j = 0; j < joints[t].length; j++) {
+            joints[t][j][0] -= pelvis[0];
+            joints[t][j][1] -= pelvis[1];
+            joints[t][j][2] -= pelvis[2];
+          }
+        }
+      }
+
+      windows.add(Pose3DWindow(
+        windowIndex: windows.length,
+        frameStart: start,
+        stride: stride,
+        T: T,
+        joints3D: joints,
+        units: 'normalized',
+        rootJoint: 'pelvis',
+        pelvisCentered: pelvisCentered,
+        notes: 'inputs normalized: centered & scaled by min(W,H)/2',
+      ));
+
+      for (int t = 0; t < joints.length; t++) {
+        final sourceIndex = window.indices[t];
+        if (sourceIndex < 0 || sourceIndex >= fused.length) continue;
+        for (int j = 0; j < 17; j++) {
+          final joint = joints[t][j];
+          fused[sourceIndex][j][0] += joint[0];
+          fused[sourceIndex][j][1] += joint[1];
+          fused[sourceIndex][j][2] += joint[2];
+          counts[sourceIndex][j] += 1;
+        }
+      }
+
+      processed++;
+      onProgress?.call(
+        PosePipelineProgress.running3d(processed: processed, total: starts.length),
+      );
+    }
+
+    for (int i = 0; i < fused.length; i++) {
+      for (int j = 0; j < fused[i].length; j++) {
+        final c = counts[i][j];
+        if (c == 0) continue;
+        fused[i][j][0] /= c;
+        fused[i][j][1] /= c;
+        fused[i][j][2] /= c;
+      }
+    }
+
+    return Pose3DResult(
+      windows: windows,
+      sequence: fused,
+      windowSize: T,
+      stride: stride,
+      pelvisCentered: pelvisCentered,
+    );
+  }
+
+  Pose2DFrame _emptyFrame(int index, double fps) => Pose2DFrame(
+        frameIndex: index,
+        t: index / fps,
+        imgW: 640,
+        imgH: 640,
+        keypoints: List.generate(
+          17,
+          (j) => PoseKeypoint2D(id: j, x: 0.0, y: 0.0, c: 0.0),
+        ),
+      );
+
+  Future<List<OrtValue?>> _run(OrtSession session, Map<String, OrtValue> inputs) async {
     final opts = OrtRunOptions();
-    final outs = await s.runAsync(opts, inputs);
+    final outs = await session.runAsync(opts, inputs);
     opts.release();
-    for (final v in inputs.values) { v.release(); }
+    for (final v in inputs.values) {
+      v.release();
+    }
     return outs ?? const [];
   }
 
-  // ---------- YOLOv8 preprocessing
+  OrtValue _prepYolo(img.Image im) {
+    final w = im.width;
+    final h = im.height;
+    final plane = w * h;
+    final buf = Float32List(3 * plane);
+    final bytes = im.getBytes(order: img.ChannelOrder.rgb);
 
-  OrtValue _prepYolo(Uint8List jpgBytes) {
-    final im = img.decodeImage(jpgBytes)!; // expect 640x640 (letterboxed by sampler)
-    final w = im.width, h = im.height;
-    final chw = Float32List(1 * 3 * h * w);
-    int i = 0;
-    for (int c = 0; c < 3; c++) {
-      for (int y = 0; y < h; y++) {
-        for (int x = 0; x < w; x++) {
-          final p = im.getPixel(x, y);
-          final r = getRed(p), g = getGreen(p), b = getBlue(p);
-          final v = (c == 0 ? r : (c == 1 ? g : b)) / 255.0;
-          chw[i++] = v;
-        }
-      }
+    for (int i = 0, p = 0; p < plane; p++) {
+      final r = bytes[i++] / 255.0;
+      final g = bytes[i++] / 255.0;
+      final b = bytes[i++] / 255.0;
+      buf[p] = r;
+      buf[plane + p] = g;
+      buf[(plane << 1) + p] = b;
     }
-    return OrtValueTensor.createTensorWithDataList(chw, [1, 3, h, w]);
+    return OrtValueTensor.createTensorWithDataList(buf, [1, 3, h, w]);
   }
 
-  // Robust YOLO decode: supports [1,N,84] and [1,84,N], uses obj×class(person) scoring.
   _Det? _pickBestPerson(OrtValue out) {
     final v = out.value;
     if (v is! List || v.isEmpty) return null;
-    if (v[0] is! List) return null;
+    final first = v[0];
+    if (first is! List || first.isEmpty) return null;
 
-    // v[0] can be [N,84] or [84,N]
-    final l0 = v[0] as List;
-    if (l0.isEmpty) return null;
-
-    // Determine layout by inspecting first inner list length.
-    bool isNx84;
-    if (l0[0] is List) {
-      final firstInner = l0[0] as List;
-      isNx84 = firstInner.length == 84; // [1, N, 84]
-    } else {
-      return null;
-    }
-
-    // Build rows = [cx, cy, w, h, obj, c0..c79]
-    final rows = <List<double>>[];
-    if (isNx84) {
+    List<List<double>> rows;
+    if (first[0] is List) {
       // [1, N, 84]
-      for (final r in (v[0] as List)) {
-        rows.add((r as List).map((e) => (e as num).toDouble()).toList());
-      }
+      rows = (first as List)
+          .map<List<double>>(
+            (row) => (row as List).map((e) => (e as num).toDouble()).toList(),
+          )
+          .toList();
     } else {
-      // [1, 84, N] -> transpose to [N,84]
-      final C = (v[0] as List).length; // 84
-      final N = ((v[0] as List)[0] as List).length;
-      for (int n = 0; n < N; n++) {
+      // [1, 84, N] -> transpose
+      final channels = (v[0] as List).length;
+      final proposals = ((v[0] as List)[0] as List).length;
+      rows = List.generate(proposals, (n) {
         final row = <double>[];
-        for (int c = 0; c < C; c++) {
+        for (int c = 0; c < channels; c++) {
           row.add((((v[0] as List)[c] as List)[n] as num).toDouble());
         }
-        rows.add(row);
-      }
+        return row;
+      });
     }
 
     double bestScore = 0.0;
     _Det? best;
     for (final r in rows) {
       if (r.length < 84) continue;
-      final cx = r[0], cy = r[1], w = r[2], h = r[3];
-
-      // Proper YOLO scoring: sigmoid(obj) * sigmoid(class_person)
-      final obj = 1.0 / (1.0 + math.exp(-r[4]));
-      final clsPerson = 1.0 / (1.0 + math.exp(-r[5])); // COCO class 0 = person
-      final score = obj * clsPerson;
-      if (score < 0.10) continue; // relaxed threshold
-
+      final cx = r[0];
+      final cy = r[1];
+      final w = r[2];
+      final h = r[3];
+      final obj = _sigmoid(r[4]);
+      final cls = _sigmoid(r[5]);
+      final score = obj * cls;
+      if (score < 0.10) continue;
       final x1 = (cx - w / 2).clamp(0.0, 640.0);
       final y1 = (cy - h / 2).clamp(0.0, 640.0);
       final x2 = (cx + w / 2).clamp(0.0, 640.0);
       final y2 = (cy + h / 2).clamp(0.0, 640.0);
       if (x2 <= x1 || y2 <= y1) continue;
-
       if (score > bestScore) {
         bestScore = score;
         best = _Det(x1, y1, x2, y2, score);
@@ -170,43 +523,60 @@ class PosePipeline {
 
   double _sigmoid(double x) => 1 / (1 + math.exp(-x));
 
-  // ---------- RTMPose cropping + preprocessing
-
   _CropResult _cropForRtm(Uint8List jpg, _Det det, {required int outH, required int outW}) {
-    final im = img.decodeImage(jpg)!; // 640x640
+    final im = img.decodeImage(jpg)!;
     final x1 = det.x1.clamp(0.0, im.width.toDouble());
     final y1 = det.y1.clamp(0.0, im.height.toDouble());
     final x2 = det.x2.clamp(0.0, im.width.toDouble());
     final y2 = det.y2.clamp(0.0, im.height.toDouble());
 
-    final w = (x2 - x1), h = (y2 - y1);
+    final w = (x2 - x1);
+    final h = (y2 - y1);
     const scale = 1.25;
-    final cx = (x1 + x2) / 2, cy = (y1 + y2) / 2;
-    final halfW = (w * scale) / 2, halfH = (h * scale) / 2;
+    final cx = (x1 + x2) / 2;
+    final cy = (y1 + y2) / 2;
+    final halfW = (w * scale) / 2;
+    final halfH = (h * scale) / 2;
     final rx1 = (cx - halfW).clamp(0.0, im.width.toDouble()).toInt();
     final ry1 = (cy - halfH).clamp(0.0, im.height.toDouble()).toInt();
     final rx2 = (cx + halfW).clamp(0.0, im.width.toDouble()).toInt();
     final ry2 = (cy + halfH).clamp(0.0, im.height.toDouble()).toInt();
 
-    final crop = img.copyCrop(im, x: rx1, y: ry1, width: (rx2 - rx1), height: (ry2 - ry1));
+    final crop = img.copyCrop(
+      im,
+      x: rx1,
+      y: ry1,
+      width: (rx2 - rx1),
+      height: (ry2 - ry1),
+    );
+
     final resized = img.copyResize(
-      crop, width: outW, height: outH, interpolation: img.Interpolation.average);
+      crop,
+      width: outW,
+      height: outH,
+      interpolation: img.Interpolation.average,
+    );
 
     final meta = _CropMeta(
-      srcW: im.width, srcH: im.height,
-      roiX: rx1.toDouble(), roiY: ry1.toDouble(),
-      roiW: (rx2 - rx1).toDouble(), roiH: (ry2 - ry1).toDouble(),
-      outW: outW, outH: outH,
+      srcW: im.width,
+      srcH: im.height,
+      roiX: rx1.toDouble(),
+      roiY: ry1.toDouble(),
+      roiW: (rx2 - rx1).toDouble(),
+      roiH: (ry2 - ry1).toDouble(),
+      outW: outW,
+      outH: outH,
     );
     return _CropResult(resized, meta);
   }
 
   OrtValue _prepRtm(img.Image patch) {
     const mean = [0.485, 0.456, 0.406];
-    const std  = [0.229, 0.224, 0.225];
+    const std = [0.229, 0.224, 0.225];
 
-    final h = patch.height, w = patch.width; // 256x192
-    final chw = Float32List(1 * 3 * h * w);
+    final h = patch.height;
+    final w = patch.width;
+    final buf = Float32List(3 * h * w);
     int i = 0;
     for (int c = 0; c < 3; c++) {
       for (int y = 0; y < h; y++) {
@@ -220,36 +590,67 @@ class PosePipeline {
               : c == 1
                   ? (g - mean[1]) / std[1]
                   : (b - mean[2]) / std[2];
-          chw[i++] = v;
+          buf[i++] = v;
         }
       }
     }
-    return OrtValueTensor.createTensorWithDataList(chw, [1, 3, h, w]);
+    return OrtValueTensor.createTensorWithDataList(buf, [1, 3, h, w]);
   }
 
-  // Decode SIMCC outputs: outs = [(1,17,384), (1,17,512)]
+  List<List<double>> _decodeAuto(List<OrtValue?> outs, _CropMeta meta) {
+    if (outs.isEmpty || outs[0] == null) {
+      return List.generate(17, (_) => [0.0, 0.0, 0.0]);
+    }
+
+    final v0 = outs[0]!.value;
+    final s0 = _shapeOf(v0);
+
+    if (s0.length == 4) {
+      return _decodeHeatmap(outs[0]!, meta);
+    }
+
+    if (outs.length >= 2) {
+      final s1 = _shapeOf(outs[1]!.value);
+      final looksSimCC =
+          s0.length == 3 && s1.length == 3 && s0[0] == 1 && s1[0] == 1;
+      if (looksSimCC) {
+        final xFirst = s0.last <= s1.last;
+        return _decodeSimCC(xFirst ? outs : [outs[1], outs[0]], meta);
+      }
+    }
+
+    return _decodeHeatmap(outs[0]!, meta);
+  }
+
   List<List<double>> _decodeSimCC(List<OrtValue?> outs, _CropMeta meta) {
-    final simccX = _toList3D(outs[0]!.value); // [1,17,384]
-    final simccY = _toList3D(outs[1]!.value); // [1,17,512]
+    final simccX = _toList3D(outs[0]!.value);
+    final simccY = _toList3D(outs[1]!.value);
     const split = 2.0;
 
-    final List<List<double>> kpts = List.generate(17, (_) => [0.0, 0.0, 0.0]);
+    final List<List<double>> kpts =
+        List.generate(17, (_) => [0.0, 0.0, 0.0]);
     for (int j = 0; j < 17; j++) {
       final rowX = simccX[0][j];
       final rowY = simccY[0][j];
-
       int ix = 0, iy = 0;
       double vx = -1e9, vy = -1e9;
-      for (int t = 0; t < rowX.length; t++) { if (rowX[t] > vx) { vx = rowX[t]; ix = t; } }
-      for (int t = 0; t < rowY.length; t++) { if (rowY[t] > vy) { vy = rowY[t]; iy = t; } }
-
-      final px = ix / split; // 0..192
-      final py = iy / split; // 0..256
-
+      for (int t = 0; t < rowX.length; t++) {
+        if (rowX[t] > vx) {
+          vx = rowX[t];
+          ix = t;
+        }
+      }
+      for (int t = 0; t < rowY.length; t++) {
+        if (rowY[t] > vy) {
+          vy = rowY[t];
+          iy = t;
+        }
+      }
+      final px = ix / split;
+      final py = iy / split;
       final x = meta.roiX + (px / meta.outW) * meta.roiW;
       final y = meta.roiY + (py / meta.outH) * meta.roiH;
-      final conf = math.min(1.0, math.max(0.0, (vx + vy) / 2.0)); // rough
-
+      final conf = math.min(1.0, math.max(0.0, (vx + vy) / 2.0));
       kpts[j][0] = x;
       kpts[j][1] = y;
       kpts[j][2] = conf;
@@ -257,9 +658,43 @@ class PosePipeline {
     return kpts;
   }
 
-  // ---------- NEW: auto-detect SimCC vs Heatmap and decode accordingly
+  List<List<double>> _decodeHeatmap(OrtValue heat, _CropMeta meta) {
+    final n1 = heat.value as List;
+    if (n1.isEmpty) return List.generate(17, (_) => [0.0, 0.0, 0.0]);
+    final nk = n1[0] as List;
+    final K = nk.length;
+    final H = (nk[0] as List).length;
+    final W = ((nk[0] as List)[0] as List).length;
 
-  // Inspect nested list tensor shape (for debug/branching)
+    final List<List<double>> kpts =
+        List.generate(17, (_) => [0.0, 0.0, 0.0]);
+
+    for (int j = 0; j < math.min(K, 17); j++) {
+      final plane = nk[j] as List;
+      double best = -1e9;
+      int by = 0, bx = 0;
+      for (int y = 0; y < H; y++) {
+        final row = plane[y] as List;
+        for (int x = 0; x < W; x++) {
+          final v = (row[x] as num).toDouble();
+          if (v > best) {
+            best = v;
+            by = y;
+            bx = x;
+          }
+        }
+      }
+      final px = (bx + 0.5) * (meta.outW / W);
+      final py = (by + 0.5) * (meta.outH / H);
+      final x = meta.roiX + (px / meta.outW) * meta.roiW;
+      final y = meta.roiY + (py / meta.outH) * meta.roiH;
+      kpts[j][0] = x;
+      kpts[j][1] = y;
+      kpts[j][2] = 1.0;
+    }
+    return kpts;
+  }
+
   List<int> _shapeOf(dynamic v) {
     final dims = <int>[];
     dynamic a = v;
@@ -270,135 +705,167 @@ class PosePipeline {
     return dims;
   }
 
-  // Unified decoder: chooses SimCC or Heatmap at runtime based on output shapes.
-  List<List<double>> _decodeAuto(List<OrtValue?> outs, _CropMeta meta) {
-    if (outs.isEmpty || outs[0] == null) {
-      return List.generate(17, (_) => [0.0, 0.0, 0.0]);
-    }
+  List<List<double>> _remapToH36M(List<List<double>> rtm) {
+    const nose = 0;
+    const leftShoulder = 5;
+    const rightShoulder = 6;
+    const leftElbow = 7;
+    const rightElbow = 8;
+    const leftWrist = 9;
+    const rightWrist = 10;
+    const leftHip = 11;
+    const rightHip = 12;
+    const leftKnee = 13;
+    const rightKnee = 14;
+    const leftAnkle = 15;
+    const rightAnkle = 16;
 
-    final v0 = outs[0]!.value;
-    final s0 = _shapeOf(v0);
-
-    // Heatmap ONNX commonly returns [1, K, H, W]
-    if (s0.length == 4) {
-      return _decodeHeatmap(outs[0]!, meta);
-    }
-
-    // SimCC ONNX: two outputs [1, K, 384] & [1, K, 512] (order may vary)
-    if (outs.length >= 2) {
-      final s1 = _shapeOf(outs[1]!.value);
-      final looksSimCC = s0.length == 3 && s1.length == 3 && s0[0] == 1 && s1[0] == 1;
-      if (looksSimCC) {
-        // Pick the smaller "bins" tensor as X (usually 384 < 512)
-        final xFirst = s0.isNotEmpty && s1.isNotEmpty && s0.last <= s1.last;
-        return _decodeSimCC(xFirst ? outs : [outs[1], outs[0]], meta);
+    List<double> avg(List<List<double>> pts) {
+      if (pts.isEmpty) return [0.0, 0.0, 0.0];
+      double x = 0, y = 0, c = 0;
+      for (final p in pts) {
+        x += p[0];
+        y += p[1];
+        c += p.length > 2 ? p[2] : 0.0;
       }
+      final n = pts.length.toDouble();
+      return [x / n, y / n, c / n];
     }
 
-    // Fallback: try heatmap on first output
-    return _decodeHeatmap(outs[0]!, meta);
+    final pelvis = avg([rtm[leftHip], rtm[rightHip]]);
+    final thorax = avg([rtm[leftShoulder], rtm[rightShoulder]]);
+    final neck = avg([thorax, rtm[nose]]);
+    final head = avg([rtm[nose], avg([rtm[leftShoulder], rtm[rightShoulder]])]);
+
+    final h36m = List.generate(17, (_) => [0.0, 0.0, 0.0]);
+    h36m[0] = pelvis;
+    h36m[1] = List<double>.from(rtm[rightHip]);
+    h36m[2] = List<double>.from(rtm[rightKnee]);
+    h36m[3] = List<double>.from(rtm[rightAnkle]);
+    h36m[4] = List<double>.from(rtm[leftHip]);
+    h36m[5] = List<double>.from(rtm[leftKnee]);
+    h36m[6] = List<double>.from(rtm[leftAnkle]);
+    h36m[7] = avg([pelvis, thorax]);
+    h36m[8] = thorax;
+    h36m[9] = neck;
+    h36m[10] = head;
+    h36m[11] = List<double>.from(rtm[leftShoulder]);
+    h36m[12] = List<double>.from(rtm[leftElbow]);
+    h36m[13] = List<double>.from(rtm[leftWrist]);
+    h36m[14] = List<double>.from(rtm[rightShoulder]);
+    h36m[15] = List<double>.from(rtm[rightElbow]);
+    h36m[16] = List<double>.from(rtm[rightWrist]);
+    return h36m;
   }
 
-  // Heatmap decoder: argmax per joint over H×W plane, then map from 256×192 crop back to full frame.
-  List<List<double>> _decodeHeatmap(OrtValue heat, _CropMeta meta) {
-    // heat.value is nested lists [1][K][H][W]
-    final n1 = heat.value as List;            // [1]
-    if (n1.isEmpty) return List.generate(17, (_) => [0.0, 0.0, 0.0]);
-    final nk = n1[0] as List;                 // [K]
-    final K = nk.length;
-
-    // infer H, W from first joint
-    final H = (nk[0] as List).length;
-    final W = ((nk[0] as List)[0] as List).length;
-
-    final List<List<double>> kpts = List.generate(17, (_) => [0.0, 0.0, 0.0]);
-    for (int j = 0; j < (K < 17 ? K : 17); j++) {
-      final plane = nk[j] as List;            // [H][W]
-      double best = -1e9;
-      int by = 0, bx = 0;
-      for (int y = 0; y < H; y++) {
-        final row = plane[y] as List;
-        for (int x = 0; x < W; x++) {
-          final v = (row[x] as num).toDouble();
-          if (v > best) { best = v; by = y; bx = x; }
-        }
-      }
-
-      // Back to 256×192 crop coords (center of the heatmap cell)
-      final px = (bx + 0.5) * (meta.outW / W);
-      final py = (by + 0.5) * (meta.outH / H);
-
-      // Then to the 640×640 letterbox ROI in the original frame
-      final x = meta.roiX + (px / meta.outW) * meta.roiW;
-      final y = meta.roiY + (py / meta.outH) * meta.roiH;
-
-      kpts[j][0] = x;
-      kpts[j][1] = y;
-      kpts[j][2] = 1.0; // optional: normalize best and set as confidence
+  _WindowPayload _prepareWindow(List<Pose2DFrame> frames, int start, int T) {
+    final list = <Pose2DFrame>[];
+    final indices = <int>[];
+    for (int offset = 0; offset < T; offset++) {
+      final idx = start + offset;
+      final mapped = _reflectIndex(idx, frames.length);
+      indices.add(mapped);
+      list.add(frames[mapped]);
     }
-    return kpts;
+    return _WindowPayload(list, indices);
   }
 
-  OrtValue _toMbInput(List<List<List<double>>> k2d) {
-    final T = k2d.length;
+  int _reflectIndex(int idx, int length) {
+    if (length <= 1) return 0;
+    if (idx < length) return idx;
+    final period = 2 * length - 2;
+    var pos = idx % period;
+    if (pos < length) return pos;
+    return period - pos;
+  }
+
+  List<int> _computeWindowStarts(int totalFrames, int window, int stride) {
+    if (totalFrames <= window) {
+      return [0];
+    }
+    final starts = <int>[];
+    int start = 0;
+    while (start + window <= totalFrames) {
+      starts.add(start);
+      start += stride;
+    }
+    final lastStart = math.max(0, totalFrames - window);
+    if (starts.isEmpty || starts.last != lastStart) {
+      starts.add(lastStart);
+    }
+    return starts;
+  }
+
+  OrtValue _toMotionBertInput(List<Pose2DFrame> frames) {
+    final T = frames.length;
     final buf = Float32List(1 * T * 17 * 3);
     int i = 0;
-    for (int t = 0; t < T; t++) {
-      for (int j = 0; j < 17; j++) {
-        buf[i++] = k2d[t][j][0].toDouble();
-        buf[i++] = k2d[t][j][1].toDouble();
-        buf[i++] = k2d[t][j][2].toDouble();
+    for (final frame in frames) {
+      final cx = frame.imgW / 2.0;
+      final cy = frame.imgH / 2.0;
+      final scale = math.max(1e-6, math.min(frame.imgW, frame.imgH) / 2.0);
+      for (final kp in frame.keypoints) {
+        buf[i++] = ((kp.x - cx) / scale).toDouble();
+        buf[i++] = ((kp.y - cy) / scale).toDouble();
+        buf[i++] = (kp.c ?? 1.0).toDouble();
       }
     }
     return OrtValueTensor.createTensorWithDataList(buf, [1, T, 17, 3]);
   }
 
-  // -------- list helpers
-
-  Float32List _toFloat32(dynamic v) {
-    if (v is Float32List) return v;
-    if (v is List) {
-      final flat = <double>[];
-      void walk(dynamic a) {
-        if (a is List) { for (final e in a) walk(e); }
-        else if (a is num) flat.add(a.toDouble());
-      }
-      walk(v);
-      return Float32List.fromList(flat);
-    }
-    return Float32List(0);
-  }
-
   List<List<List<double>>> _toList3D(dynamic v) =>
-      (v as List).map<List<List<double>>>((a) =>
-        (a as List).map<List<double>>((b) =>
-          (b as List).map<double>((c) => (c as num).toDouble()).toList()
-        ).toList()
-      ).toList();
+      (v as List)
+          .map<List<List<double>>>((a) =>
+              (a as List)
+                  .map<List<double>>((b) =>
+                      (b as List).map<double>((c) => (c as num).toDouble()).toList())
+                  .toList())
+          .toList();
 
   List<List<List<List<double>>>> _toList4D(dynamic v, {required List<int> dims}) {
-    return (v as List).map<List<List<List<double>>>>((a) =>
-      (a as List).map<List<List<double>>>((b) =>
-        (b as List).map<List<double>>((c) =>
-          (c as List).map<double>((d) => (d as num).toDouble()).toList()
-        ).toList()
-      ).toList()
-    ).toList();
+    return (v as List)
+        .map<List<List<List<double>>>>((a) =>
+            (a as List)
+                .map<List<List<double>>>((b) =>
+                    (b as List)
+                        .map<List<double>>((c) =>
+                            (c as List)
+                                .map<double>((d) => (d as num).toDouble())
+                                .toList())
+                        .toList())
+                .toList())
+        .toList();
   }
 }
 
-class _Det { _Det(this.x1, this.y1, this.x2, this.y2, this.score);
-  final double x1, y1, x2, y2, score; }
+class _Det {
+  _Det(this.x1, this.y1, this.x2, this.y2, this.score);
+  final double x1, y1, x2, y2, score;
+}
 
 class _CropMeta {
   _CropMeta({
-    required this.srcW, required this.srcH,
-    required this.roiX, required this.roiY,
-    required this.roiW, required this.roiH,
-    required this.outW, required this.outH,
+    required this.srcW,
+    required this.srcH,
+    required this.roiX,
+    required this.roiY,
+    required this.roiW,
+    required this.roiH,
+    required this.outW,
+    required this.outH,
   });
   final int srcW, srcH, outW, outH;
   final double roiX, roiY, roiW, roiH;
 }
-class _CropResult { _CropResult(this.image, this.meta);
-  final img.Image image; final _CropMeta meta; }
+
+class _CropResult {
+  _CropResult(this.image, this.meta);
+  final img.Image image;
+  final _CropMeta meta;
+}
+
+class _WindowPayload {
+  _WindowPayload(this.frames, this.indices);
+  final List<Pose2DFrame> frames;
+  final List<int> indices;
+}

--- a/lib/shared/widgets/processing_banner.dart
+++ b/lib/shared/widgets/processing_banner.dart
@@ -1,0 +1,127 @@
+// lib/shared/widgets/processing_banner.dart
+import 'package:flutter/material.dart';
+
+import '../services/pose_processing_controller.dart';
+
+class ProcessingBanner extends StatelessWidget {
+  const ProcessingBanner({
+    super.key,
+    required this.event,
+    this.onCancel,
+  });
+
+  final ProgressEvent event;
+  final VoidCallback? onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final radius = BorderRadius.circular(18);
+    final isDeterminate = event.status == ProgressStatus.determinate;
+    final isIndeterminate = event.status == ProgressStatus.indeterminate;
+    final isError = event.status == ProgressStatus.error;
+    final isComplete = event.status == ProgressStatus.complete;
+    final phase = event.phase ?? (isError ? 'Error' : 'Processing');
+
+    return Material(
+      color: Colors.transparent,
+      elevation: 8,
+      borderRadius: radius,
+      child: Container(
+        width: 360,
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 18),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surface,
+          borderRadius: radius,
+          boxShadow: const [
+            BoxShadow(
+              color: Color(0x1A000000),
+              blurRadius: 18,
+              offset: Offset(0, 8),
+            )
+          ],
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  isError
+                      ? Icons.error_outline
+                      : isComplete
+                          ? Icons.check_circle_outline
+                          : Icons.blur_circular,
+                  color: isError
+                      ? theme.colorScheme.error
+                      : theme.colorScheme.primary,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    phase,
+                    style: textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            if (isIndeterminate)
+              const LinearProgressIndicator(minHeight: 5)
+            else if (isDeterminate)
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  LinearProgressIndicator(
+                    value: event.value?.clamp(0.0, 1.0),
+                    minHeight: 5,
+                  ),
+                  const SizedBox(height: 6),
+                  if (event.processed != null && event.total != null)
+                    Text(
+                      '${event.processed} of ${event.total} windows',
+                      style: textTheme.bodySmall,
+                    )
+                  else
+                    Text(
+                      '${((event.value ?? 0) * 100).clamp(0, 100).toStringAsFixed(0)}%',
+                      style: textTheme.bodySmall,
+                    ),
+                ],
+              )
+            else if (isError)
+              Text(
+                event.message ?? 'Processing failed.',
+                style: textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.error,
+                ),
+              )
+            else if (isComplete)
+              Text(
+                'All pose data is ready.',
+                style: textTheme.bodyMedium,
+              ),
+            if (event.allowCancel &&
+                onCancel != null &&
+                (isDeterminate || isIndeterminate))
+              Align(
+                alignment: Alignment.centerRight,
+                child: TextButton.icon(
+                  onPressed: onCancel,
+                  icon: const Icon(Icons.close_rounded),
+                  label: const Text('Cancel'),
+                  style: TextButton.styleFrom(
+                    foregroundColor: theme.colorScheme.primary,
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- refactor the offline pose runtime to extract RTM-Pose frames, remap them to H36M-17, and window MotionBERT inference with stride-aware progress callbacks
- add a pose processing controller that writes session metadata, 2D JSONL frames, and 3D windows while emitting cancellable progress events and meta summaries
- integrate the controller into the recording flow with a ProcessingBanner overlay so post-recording 3D analysis runs automatically and navigates to feedback on success

## Testing
- Not run (Flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_b_68de20603100832f8ca1a7c6a0f35bbb