### PR TITLE
Implement pipeline debug instrumentation

### DIFF
--- a/docs/debug_playbook.md
+++ b/docs/debug_playbook.md
@@ -1,0 +1,249 @@
+# FitPerfect Debug Playbook
+
+This playbook helps diagnose issues across the FitPerfect capture pipeline quickly. Enable the one-time debug switch to collect structured logs and artifacts, then follow the stage-by-stage guidance below.
+
+## 0. Enable debug mode
+
+Introduce a single boolean `debug` flag (e.g., surfaced in app settings). When enabled, each stage:
+
+- Emits structured JSON logs to both the console and a session-specific log file.
+- Saves small inspection artifacts (first frames, tiny JSON snippets, PNG/JPG overlays) into the session directory.
+
+**Session folder**: `Documents/FitPerfect/<sessionId>/`, obtained via `getApplicationDocumentsDirectory()` on iOS/Android. Treat this as the canonical location for all per-run artifacts.
+
+---
+
+## 1. Camera capture & YUV → RGB
+
+**Log every ~30 frames, plus first and last frames:**
+
+- `CAM`: camera resolution, rotation/orientation, frame index `t`, timestamp (ms).
+- `YUV2RGB`: converter path (native vs Dart), average conversion time, output tensor shape `[H, W, 3]`.
+
+**Persist (first frame):** `frame_0000_rgb.jpg` for visual sanity (orientation & color order).
+
+**Failure signatures:**
+
+| Symptom | Likely cause |
+| --- | --- |
+| Skin appears blue/green | Incorrect YUV→RGB conversion order (channel swap). |
+| Severe frame drops | Conversion executing on UI thread/Dart—prefer native or FFI implementation. |
+
+---
+
+## 2. Letterbox (YOLO input 640×640, pad=114)
+
+**Log first 5 frames, then every ~60:**
+
+- `LBX`: source height/width, scale `r`, padding offsets `dw`, `dh`, fill color `[114,114,114]`, output shape `640×640`.
+
+**Persist (first frame):** `t0000_letterbox.jpg`.
+
+> YOLOv8 expects neutral gray padding (114). Keep this constant—do not auto-tune.
+
+**Failure signatures:**
+
+- Incorrect `r/dw/dh` results in wrong un-padding later (boxes cling to edges).
+- Missing padding distorts subjects and harms detections.
+
+---
+
+## 3. YOLO inference & decode
+
+**Log every frame:**
+
+- `YOLO_IN`: input tensor shape (target `[1,3,640,640]`), normalization (RGB/255 confirmation).
+- `YOLO_EP`: active execution provider (CoreML/XNNPACK/CPU) and per-frame latency.
+- `YOLO_RAW`: output tensor shape (e.g., `[1,84,8400]`) and first three values.
+- `YOLO_DET`: candidate count pre-NMS, top score, selected bbox in letterbox coordinates, normalization flag.
+
+**Persist:** `yolo_decode.txt` with entries such as `t=0 valid=3087 chosen_score=0.71 bbox=[x1,y1,x2,y2]`.
+
+**Notes:**
+
+- iOS logs like `IsInputSupported: Dynamic shape is not supported …` indicate CoreML fallback to CPU. Mitigate by enabling the CoreML flag `onlyAllowStaticInputShapes` or running YOLO/RTM exclusively on XNNPACK.
+
+**Failure signatures:**
+
+| Symptom | Likely cause |
+| --- | --- |
+| Person detected late (~50/60 frames) | Threshold/NMS too strict or faulty un-letterboxing. |
+| BBox `[0,…,0,…]` | Normalized outputs never rescaled/un-padded. |
+
+---
+
+## 4. Un-letterbox to original coordinates
+
+For each selected detection compute:
+
+```
+x1_img = (x1_lb - dw) / r
+x2_img = (x2_lb - dw) / r
+y1_img = (y1_lb - dh) / r
+y2_img = (y2_lb - dh) / r
+```
+
+**Log:** final image-space bbox per frame.
+
+**Persist:** overlay every ~60 frames (`bbox_overlay_t0060.jpg`) showing the bbox on the original RGB frame.
+
+**Failure signatures:** incorrect `r/dw/dh` yields misaligned crops, confusing downstream models.
+
+---
+
+## 5. Crop → 256×192 & RTMPose (SimCC)
+
+**Log every frame or every 5 frames:**
+
+- `CROP`: selected bbox, adjusted crop rectangle, scale factor (e.g., ×1.25), output size `256×192`.
+- `RTM_IN`: tensor shape `[1,3,256,192]`, preprocessing (RGB/255).
+- `RTM_EP`: execution provider, timings.
+- `RTM_OUT`: SimCC tensor shapes (e.g., `X=384`, `Y=512`), top 3 peak confidences.
+
+**Persist:**
+
+- `t0000_cropped.jpg` (first frame).
+- `t00xx_kpts_on_crop.jpg` (first frame with valid keypoints, overlayed).
+
+**Notes:**
+
+- RTMPose uses SimCC decoding; ensure decode logic matches tensor sizes and split ratio (commonly 2.0).
+
+**Failure signatures:**
+
+| Symptom | Likely cause |
+| --- | --- |
+| Near-zero confidences | Wrong color order/normalization or SimCC decode bug. |
+| Skeleton shifted/scaled | Incorrect mapping from crop to image coordinates. |
+
+---
+
+## 6. Map keypoints back to image & overlay
+
+**Log every ~10 frames:**
+
+- `KPTS_IMG`: min/max `(x,y)` across 17 joints, mean confidence, `x_ptp`/`y_ptp` ranges.
+- Record tracker status (`TRACKER`) when fallback boxes are reused.
+
+**Persist:** `overlay_t00xx.jpg` combining original image, bbox, and skeleton.
+
+**Expected ranges:**
+
+- `conf_mean` ≫ 0.002.
+- `x_ptp`/`y_ptp` should span hundreds of pixels on 1080p frames.
+
+---
+
+## 7. Save 2D sequence (JSONL)
+
+**Writer flow:**
+
+1. `2D_SAVE_OPEN`: log path to `coco_2d.jsonl` (once per session).
+2. `2D_SAVE_WRITE`: per frame JSON line: 
+   ```json
+   {
+     "t": 0.033,
+     "img_w": 1080,
+     "img_h": 1920,
+     "bbox_norm": [x1/W, y1/H, x2/W, y2/H],
+     "kpt_h36m": [[x,y,conf], ... 17],
+     "yolo_units": "normalized",
+     "lbx": {"r":0.58,"dw":12,"dh":48}
+   }
+   ```
+3. `2D_SAVE_FLUSH` & `2D_SAVE_CLOSE`: confirm bytes written after recording stops.
+
+**Reader flow:** search `Documents/FitPerfect/<sessionId>/coco_2d.jsonl`. If legacy paths (`…/poses/<sessionId>/2d/frames.jsonl`) remain, log which was used.
+
+**Failure signatures:**
+
+- Missing summary data: mismatched session IDs, incorrect directory, or writer never flushed/closed.
+
+---
+
+## 8. MotionBERT (post-record 3D)
+
+**Pre-run logs:**
+
+- `MB_PREP`: total frames, keypoint mapping (COCO→H36M if needed), normalization strategy, window size (243) and stride.
+- `MB_EP`: provider choice and timing.
+
+**Run logs:**
+
+- `MB_RUN`: input shape `[1,243,17,3]`, elapsed ms.
+- `MB_OUT`: Z-range (min/max), representative frame sample.
+
+**Persist:** `out_3d.json`, optional `mb_input_seq.npy`, and `mb_quick_stats.json` (frame count, z-range).
+
+> MotionBERT expects H36M-17 keypoints. Match Python normalization: center & scale by min-side, maintain consistent padding/truncation for the 243-frame window.
+
+---
+
+## 9. Execution providers & model shapes (iOS)
+
+**Session start logs:**
+
+- `ORT_ENV`: ONNX Runtime version & build flags.
+- `EP_CHAIN`: ordered provider chain (e.g., `CoreML(staticOnly=true) → XNNPACK → CPU`).
+- `COREML`: include `onlyAllowStaticInputShapes` and `createMLProgram` flags.
+
+**Handling warnings:**
+
+- Route dynamic-shape nodes to XNNPACK/CPU or enable static-only CoreML to avoid spam like `Dynamic shape not supported`.
+- Optionally, pre-fix dynamic shapes in ONNX via official ORT tooling.
+
+---
+
+## 10. End-to-end integrity self-check
+
+Provide a debug-only "Session Self-Check" button that reports:
+
+1. **Paths & IDs:** session folder used by writer/reader, recursive file listing.
+2. **2D sanity:** parse `coco_2d.jsonl`, compute frame count, `conf_mean`, `x_ptp`, `y_ptp`.
+3. **3D sanity:** if `out_3d.json` exists, print frame count and `z_min/z_max`.
+4. **Overlay presence:** confirm `overlay_t00xx.jpg`; if missing, suggest enabling overlay exports.
+
+---
+
+## 11. Suggested log keys & examples
+
+Recommended JSON log keys:
+
+```
+CAM, YUV2RGB, LBX, YOLO_IN, YOLO_EP, YOLO_RAW, YOLO_DET, UNPAD,
+CROP, RTM_IN, RTM_EP, RTM_OUT, SIMCC, KPTS_IMG, OVERLAY,
+2D_SAVE_OPEN, 2D_SAVE_WRITE, 2D_SAVE_CLOSE,
+MB_PREP, MB_EP, MB_RUN, MB_OUT,
+EP_CHAIN, COREML_WARN, SESSION_PATHS
+```
+
+**Sample entries:**
+
+```
+YOLO_DET {"t":14,"valid":3087,"maxScore":0.711,"bbox_lb":[0,0.86,0,2.98],"norm":true}
+UNPAD    {"t":14,"bbox_img":[150,260,960,1780],"r":0.582,"dw":12,"dh":48}
+KPTS_IMG {"t":14,"conf_mean":0.74,"x_ptp":690,"y_ptp":1520}
+2D_SAVE_WRITE {"t":14,"path":".../FitPerfect/2025-10.../coco_2d.jsonl","bytes":312}
+MB_OUT   {"frames":243,"joints":17,"z_min":-0.42,"z_max":0.61}
+```
+
+---
+
+## 12. Common failure → fix table
+
+| Symptom | Likely cause | Where to inspect | Suggested fix |
+| --- | --- | --- | --- |
+| Person appears only after 50–60 frames | YOLO threshold too high, aggressive NMS, or incorrect un-letterboxing | `YOLO_DET`, `UNPAD` | Reduce confidence/NMS thresholds; verify `r/dw/dh`; ensure normalized outputs mapped back to pixels. |
+| Keypoints cluster near `(0,0)` or confidences ≈ 0 | Broken crop or SimCC decode | `CROP`, `RTM_IN`, `RTM_OUT` | Correct crop rectangle; match SimCC tensor sizes (384/512) & split ratio; check color order and `/255` normalization. |
+| iOS logs "Dynamic shape is not supported" | CoreML execution provider declining dynamic nodes | `EP_CHAIN`, device console | Enable CoreML static-only flag; route dynamic ops to XNNPACK; or fix ONNX shapes offline. |
+| `coco_2d.jsonl` missing on summary | Session path mismatch or writer never flushed | `2D_SAVE_OPEN/CLOSE`, `SESSION_PATHS` | Ensure consistent `<sessionId>`; search both live and legacy directories; flush and close file sink. |
+| MotionBERT Z range extreme | Incorrect MotionBERT normalization | `MB_PREP` | Follow H36M-17 mapping and normalization (center + min-side scale). |
+
+---
+
+## 13. Optional: performance sampling
+
+- Record per-stage timings: `YUV2RGB_ms`, `YOLO_ms`, `RTM_ms`, `MB_ms`.
+- Compare cumulative latency against frame budget (e.g., 33 ms @ 30 FPS) and log overruns.
+- Attribute workloads to execution providers (per model or per node, when available). XNNPACK is a strong fallback accelerator on iOS/Android when CoreML/NNAPI reject certain ops.
+

--- a/lib/shared/services/live_pose.dart
+++ b/lib/shared/services/live_pose.dart
@@ -28,12 +28,17 @@ import 'package:image/image.dart' as img;
 import 'package:path_provider/path_provider.dart';
 
 import 'ort_session.dart';        // OrtManager.fromAsset / .run()
+import 'pipeline_debug_recorder.dart';
 import 'yuv_converter.dart';      // yuv420ToImage(CameraImage)
 
 /// Live 2D engine.
 class LivePoseEngine {
-  LivePoseEngine({int? frameStride, int? yoloEvery, this.roiMargin = 1.25})
-      : frameStride = frameStride ?? yoloEvery ?? 3;
+  LivePoseEngine({
+    int? frameStride,
+    int? yoloEvery,
+    this.roiMargin = 1.25,
+    this.debug = false,
+  }) : frameStride = frameStride ?? yoloEvery ?? 3;
 
   /// Process every Nth frame (sampling). Default 3 if not specified.
   final int frameStride;
@@ -41,10 +46,23 @@ class LivePoseEngine {
   /// Scale bbox a bit when cropping for RTM (e.g., 1.25).
   final double roiMargin;
 
+  /// Enable verbose pipeline diagnostics.
+  final bool debug;
+
+  static const List<String> _defaultProviders =
+      ['coreml', 'nnapi', 'xnnpack', 'cpu'];
+
   // ───────────── runtime state ─────────────
   bool _running = false;
   bool _busy = false;
   int _frameIndex = 0;
+
+  PipelineDebugRecorder? _debugger;
+  CameraController? _controller;
+  bool _savedFirstRgb = false;
+  bool _savedLetterbox = false;
+  bool _savedCrop = false;
+  int _lastOverlayFrame = -1;
 
   // Where 2D JSONL is written during live session.
   IOSink? _jsonlSink;
@@ -75,6 +93,12 @@ class LivePoseEngine {
     if (_running) return _sessionId;
     _running = true;
 
+    _controller = controller;
+    _savedFirstRgb = false;
+    _savedLetterbox = false;
+    _savedCrop = false;
+    _lastOverlayFrame = -1;
+
     // Resolve session folder.
     _sessionId = sessionId ?? DateTime.now().millisecondsSinceEpoch.toString();
     final Directory baseDir = writeToDocuments
@@ -87,9 +111,39 @@ class LivePoseEngine {
     _jsonlPath = '${_sessionDir.path}/coco_2d.jsonl';
     _jsonlSink = File(_jsonlPath).openWrite(mode: FileMode.append);
 
+    _debugger = debug
+        ? PipelineDebugRecorder(
+            enabled: true,
+            sessionId: _sessionId,
+            sessionDir: _sessionDir,
+          )
+        : null;
+
+    final previewSize = controller.value.previewSize;
+    _debugger?.log('SESSION_PATHS', {
+      'sessionId': _sessionId,
+      'baseDir': baseDir.path,
+      'sessionDir': _sessionDir.path,
+      'writeToDocuments': writeToDocuments,
+    });
+    _debugger?.log('CAM_CFG', {
+      'sessionId': _sessionId,
+      'lensDirection': controller.description.lensDirection.toString(),
+      'sensorOrientation': controller.description.sensorOrientation,
+      if (previewSize != null)
+        'previewSize': [previewSize.width, previewSize.height],
+    });
+    _debugger?.log('2D_SAVE_OPEN', {
+      'path': _jsonlPath,
+    });
+
     // Init ONNX sessions once (keep in current isolate for now).
     _yolo ??= await OrtManager.fromAsset('assets/models/yolov8n.onnx');
     _rtm  ??= await OrtManager.fromAsset('assets/models/rtmpose-m_256x192.onnx');
+    _debugger?.log('EP_CHAIN', {
+      'yolo': _defaultProviders,
+      'rtm': _defaultProviders,
+    });
 
     // Start image stream.
     _frameIndex = 0;
@@ -123,7 +177,14 @@ class LivePoseEngine {
     } catch (_) {}
     await _jsonlSink?.flush();
     await _jsonlSink?.close();
+    _debugger?.log('2D_SAVE_CLOSE', {
+      'path': _jsonlPath,
+      'bytes': await File(_jsonlPath).exists()
+          ? await File(_jsonlPath).length()
+          : 0,
+    });
     _jsonlSink = null;
+    await _debugger?.close();
     return _jsonlPath;
   }
 
@@ -132,6 +193,7 @@ class LivePoseEngine {
     await _overlayDataCtl.close();
     try { await _yolo?.close(); } catch (_) {}
     try { await _rtm?.close(); } catch (_) {}
+    await _debugger?.close();
   }
 
   // ───────────────────────── optional: single-frame API ─────────────────────────
@@ -172,37 +234,169 @@ class LivePoseEngine {
   // ───────────────────────── private helpers ─────────────────────────
 
   Future<void> _processFrame(CameraImage cam) async {
-    // Convert to RGB image (stride-aware, supports BGRA8888 / YUV420 variants).
+    final dbg = _debugger;
+    final int t = _frameIndex;
+
+    if (dbg != null && dbg.shouldLog('CAM', t, every: 30, first: 2)) {
+      dbg.log('CAM', {
+        't': t,
+        'resolution': [cam.width, cam.height],
+        'format': cam.format.group.toString(),
+        'planes': cam.planes.length,
+        'timestampMs': DateTime.now().millisecondsSinceEpoch,
+        if (_controller?.value.deviceOrientation != null)
+          'deviceOrientation': _controller!.value.deviceOrientation.toString(),
+      });
+    }
+
+    final yuvTimer = Stopwatch()..start();
     final rgb = yuv420ToImage(cam);
+    final double yuvMs = yuvTimer.elapsedMicroseconds / 1000.0;
+    if (dbg != null && dbg.shouldLog('YUV2RGB', t, every: 30, first: 2)) {
+      dbg.log('YUV2RGB', {
+        't': t,
+        'converter': 'yuv420ToImage',
+        'ms': double.parse(yuvMs.toStringAsFixed(3)),
+        'outputShape': [rgb.height, rgb.width, 3],
+      });
+    }
+    if (dbg != null && dbg.enabled && !_savedFirstRgb) {
+      _savedFirstRgb = true;
+      await dbg.saveImage('frame_${t.toString().padLeft(4, '0')}_rgb.jpg', rgb);
+    }
 
-    // Letterbox to 640×640 (pad=114), keep mapping params.
+    final lbTimer = Stopwatch()..start();
     final lb = _letterbox(rgb, 640, 640, pad: const [114, 114, 114]);
+    final double lbMs = lbTimer.elapsedMicroseconds / 1000.0;
+    if (dbg != null && dbg.shouldLog('LBX', t, every: 60, first: 5)) {
+      dbg.log('LBX', {
+        't': t,
+        'src': [rgb.height, rgb.width],
+        'scale': lb.r,
+        'dw': lb.dw,
+        'dh': lb.dh,
+        'fill': const [114, 114, 114],
+        'out': [lb.image.height, lb.image.width],
+        'ms': double.parse(lbMs.toStringAsFixed(3)),
+      });
+    }
+    if (dbg != null && dbg.enabled && !_savedLetterbox) {
+      _savedLetterbox = true;
+      await dbg.saveImage('t${t.toString().padLeft(4, '0')}_letterbox.jpg', lb.image);
+    }
 
-    // Prepare YOLO input [1,3,640,640], float32 RGB/255.
     final Float32List yoloIn = _toCHWFloat32(lb.image); // 3*640*640
+    if (dbg != null && dbg.shouldLog('YOLO_IN', t, every: 30, first: 5)) {
+      dbg.log('YOLO_IN', {
+        't': t,
+        'shape': [1, 3, 640, 640],
+        'normalization': 'rgb/255',
+      });
+    }
+
+    final yoloTimer = Stopwatch()..start();
     final yoloOut = await _yolo!.run({'images': yoloIn});
+    final double yoloMs = yoloTimer.elapsedMicroseconds / 1000.0;
     final Float32List pred = _asFloat32(_pickOutput(yoloOut, key: 'output0'));
+    if (dbg != null && dbg.shouldLog('YOLO_EP', t, every: 30, first: 5)) {
+      dbg.log('YOLO_EP', {
+        't': t,
+        'providers': _defaultProviders,
+        'ms': double.parse(yoloMs.toStringAsFixed(3)),
+      });
+    }
+    if (dbg != null && dbg.shouldLog('YOLO_RAW', t, every: 30, first: 5)) {
+      final List<double> firstVals = [];
+      for (int i = 0; i < math.min(3, pred.length); i++) {
+        firstVals.add(double.parse(pred[i].toStringAsFixed(4)));
+      }
+      dbg.log('YOLO_RAW', {
+        't': t,
+        'shape': [1, 84, pred.length ~/ 84],
+        'first3': firstVals,
+      });
+    }
 
-    // Decode (assumes [1,84,N] flattened → [84*N]).
     final decode = _decodeYolo(pred, lbW: 640, lbH: 640);
-
-    // Optional NMS; for single-person we pick max-score person.
     final det = _pickBestPerson(decode);
-    if (det == null) return;
+    if (dbg != null && dbg.shouldLog('YOLO_DET', t, every: 10, first: 5)) {
+      dbg.log('YOLO_DET', {
+        't': t,
+        'valid': decode.length,
+        'maxScore': det == null ? 0.0 : (det['score'] as double),
+        'bbox_lb': det == null ? null : List<double>.from(det['xyxy'] as List),
+        'norm': true,
+      });
+    }
+    if (det == null) {
+      return;
+    }
 
-    // Unletterbox → original image pixels.
-    final boxPx = _unletterbox(det['xyxy'], lb);
+    final boxPx = _unletterbox(List<double>.from(det['xyxy'] as List<double>), lb);
+    if (dbg != null && dbg.shouldLog('UNPAD', t, every: 30, first: 5)) {
+      dbg.log('UNPAD', {
+        't': t,
+        'bbox_img': boxPx,
+        'r': lb.r,
+        'dw': lb.dw,
+        'dh': lb.dh,
+      });
+    }
 
-    // Crop with ROI margin and resize to 256×192.
-    final cropRes = _cropForRtm(rgb, boxPx, outH: 256, outW: 192, margin: roiMargin);
+    final cropRes =
+        _cropForRtm(rgb, boxPx, outH: 256, outW: 192, margin: roiMargin);
+    if (dbg != null && dbg.shouldLog('CROP', t, every: 30, first: 5)) {
+      dbg.log('CROP', {
+        't': t,
+        'bbox': boxPx,
+        'rect': [cropRes.rx, cropRes.ry, cropRes.rw, cropRes.rh],
+        'scale': roiMargin,
+        'out': [256, 192],
+      });
+    }
+    if (dbg != null && dbg.enabled && !_savedCrop) {
+      _savedCrop = true;
+      await dbg.saveImage('t${t.toString().padLeft(4, '0')}_cropped.jpg', cropRes.image);
+    }
 
-    // RTMPose input [1,3,256,192], rgb_255
     final Float32List rtmIn = _toCHWFloat32(cropRes.image);
-    final rtmOut = await _rtm!.run({'input': rtmIn});
-    final Float32List simccX = _asFloat32(_pickOutput(rtmOut, key: 'simcc_x', index: 0));
-    final Float32List simccY = _asFloat32(_pickOutput(rtmOut, key: 'simcc_y', index: 1));
+    if (dbg != null && dbg.shouldLog('RTM_IN', t, every: 30, first: 5)) {
+      dbg.log('RTM_IN', {
+        't': t,
+        'shape': [1, 3, 256, 192],
+        'normalization': 'rgb/255',
+      });
+    }
 
-    final kptsIn = _simccDecode(simccX, simccY, 17, 384, 512, splitRatio: 2.0);
+    final rtmTimer = Stopwatch()..start();
+    final rtmOut = await _rtm!.run({'input': rtmIn});
+    final double rtmMs = rtmTimer.elapsedMicroseconds / 1000.0;
+    final Float32List simccX =
+        _asFloat32(_pickOutput(rtmOut, key: 'simcc_x', index: 0));
+    final Float32List simccY =
+        _asFloat32(_pickOutput(rtmOut, key: 'simcc_y', index: 1));
+    if (dbg != null && dbg.shouldLog('RTM_EP', t, every: 30, first: 5)) {
+      dbg.log('RTM_EP', {
+        't': t,
+        'providers': _defaultProviders,
+        'ms': double.parse(rtmMs.toStringAsFixed(3)),
+      });
+    }
+
+    final kptsIn =
+        _simccDecode(simccX, simccY, 17, 384, 512, splitRatio: 2.0);
+
+    if (dbg != null && dbg.shouldLog('RTM_OUT', t, every: 30, first: 5)) {
+      final confidences = kptsIn
+          .map((kp) => kp.length > 2 ? kp[2] : 0.0)
+          .toList(growable: false);
+      confidences.sort((a, b) => b.compareTo(a));
+      dbg.log('RTM_OUT', {
+        't': t,
+        'simcc': {'x': [1, 17, 384], 'y': [1, 17, 512]},
+        'topConf': confidences.take(3).toList(),
+      });
+    }
 
     // Build overlay points and data.
     final pts = <Offset>[];
@@ -213,6 +407,40 @@ class LivePoseEngine {
       final c = kp[2];
       pts.add(Offset(x, y));
       kptsPx.add([x, y, c]);
+    }
+
+    if (dbg != null && dbg.shouldLog('KPTS_IMG', t, every: 10, first: 5)) {
+      double minX = double.infinity,
+          maxX = -double.infinity,
+          minY = double.infinity,
+          maxY = -double.infinity,
+          confSum = 0.0;
+      for (final kp in kptsPx) {
+        minX = math.min(minX, kp[0]);
+        maxX = math.max(maxX, kp[0]);
+        minY = math.min(minY, kp[1]);
+        maxY = math.max(maxY, kp[1]);
+        confSum += kp[2];
+      }
+      final confMean = kptsPx.isEmpty ? 0.0 : confSum / kptsPx.length;
+      dbg.log('KPTS_IMG', {
+        't': t,
+        'conf_mean': double.parse(confMean.toStringAsFixed(4)),
+        'x_ptp': maxX - minX,
+        'y_ptp': maxY - minY,
+      });
+    }
+
+    if (dbg != null && dbg.shouldLog('OVERLAY', t, every: 60, first: 2) &&
+        t != _lastOverlayFrame) {
+      final overlay = _drawOverlay(rgb, boxPx, kptsPx);
+      await dbg.saveImage('overlay_t${t.toString().padLeft(4, '0')}.jpg', overlay);
+      dbg.log('OVERLAY', {
+        't': t,
+        'path':
+            '${_sessionDir.path}/overlay_t${t.toString().padLeft(4, '0')}.jpg',
+      });
+      _lastOverlayFrame = t;
     }
 
     // Publish overlays (points first for UI, raw data optional).
@@ -235,6 +463,13 @@ class LivePoseEngine {
       'lb': {'r': lb.r, 'dw': lb.dw, 'dh': lb.dh},
     });
     _jsonlSink?.writeln(line);
+    if (dbg != null && dbg.shouldLog('2D_SAVE_WRITE', t, every: 30, first: 5)) {
+      dbg.log('2D_SAVE_WRITE', {
+        't': t,
+        'path': _jsonlPath,
+        'bytes': line.length,
+      });
+    }
   }
 
   // Convert img.Image (RGB888) to CHW float32 [0..1].
@@ -339,6 +574,31 @@ class LivePoseEngine {
     final crop = img.copyCrop(src, x: rx.round(), y: ry.round(), width: rw.round(), height: rh.round());
     final resized = img.copyResize(crop, width: outW, height: outH, interpolation: img.Interpolation.linear);
     return _CropResult(resized, rx, ry, rw, rh);
+  }
+
+  img.Image _drawOverlay(img.Image base, List<double> bbox, List<List<double>> kpts) {
+    final overlay = img.copyResize(base,
+        width: base.width,
+        height: base.height,
+        interpolation: img.Interpolation.nearest);
+    img.drawRect(
+      overlay,
+      bbox[0].round(),
+      bbox[1].round(),
+      bbox[2].round(),
+      bbox[3].round(),
+      color: img.ColorRgb8(0, 255, 0),
+    );
+    for (final kp in kpts) {
+      img.drawCircle(
+        overlay,
+        centerX: kp[0].round(),
+        centerY: kp[1].round(),
+        radius: 3,
+        color: img.ColorRgb8(255, 0, 0),
+      );
+    }
+    return overlay;
   }
 
   /// Minimal SimCC decoder: argmax on each joint's x/y logits.

--- a/lib/shared/services/motionbert_runner.dart
+++ b/lib/shared/services/motionbert_runner.dart
@@ -28,14 +28,17 @@ import 'dart:ui' show Size;
 import 'package:path_provider/path_provider.dart';
 
 import 'ort_session.dart'; // OrtManager.fromAsset(...)
+import 'pipeline_debug_recorder.dart';
 
 class MotionBertRunner {
   MotionBertRunner({
     this.modelAssetPath = 'assets/models/motionbert_3d_243.onnx',
+    this.debug = false,
   });
 
   /// Path to MotionBERT ONNX/ORT model inside assets.
   final String modelAssetPath;
+  final bool debug;
 
   /// Run MotionBERT 3D for a finished live session.
   /// [frameSize] must match the original image size used during 2D (width x height).
@@ -57,138 +60,212 @@ class MotionBertRunner {
       await sessionDir.create(recursive: true);
     }
 
+    final PipelineDebugRecorder? dbg = debug
+        ? PipelineDebugRecorder(
+            enabled: true,
+            sessionId: sessionId,
+            sessionDir: sessionDir,
+          )
+        : null;
+
+    dbg?.log('SESSION_PATHS', {
+      'sessionId': sessionId,
+      'sessionDir': sessionDir.path,
+      'model': modelAssetPath,
+    });
+
     final file2D = File('${sessionDir.path}/coco_2d.jsonl');
     if (!await file2D.exists()) {
       throw StateError('Missing coco_2d.jsonl at ${file2D.path}');
     }
 
-    // --- 1) Read COCO-17 sequence from jsonl
-    final seqCoco = <List<List<double>>>[]; // [T][17][3]
-    await for (final line in file2D.openRead()
-        .transform(utf8.decoder)
-        .transform(const LineSplitter())) {
-      if (line.trim().isEmpty) continue;
-      final obj = json.decode(line) as Map<String, dynamic>;
-      final kpts = (obj['kpt_coco'] as List)
-          .map<List<double>>((e) => (e as List).map((v) => (v as num).toDouble()).toList())
-          .toList();
-      if (kpts.length == 17) {
-        seqCoco.add(kpts);
-      }
-    }
-    if (seqCoco.isEmpty) {
-      throw StateError('No frames found in coco_2d.jsonl');
-    }
-
-    final int W = frameSize.width.round();
-    final int H = frameSize.height.round();
-
-    // --- 2) COCO-17 → H36M-17 (xy + conf per joint)
-    final seqH36 = <List<List<double>>>[]; // [T][17][3]
-    for (final kpts in seqCoco) {
-      final h36 = _cocoToH36M(kpts);
-      seqH36.add(h36);
-    }
-
-    // --- 3) Pad/trim to 243
-    const int T = 243;
-    List<List<List<double>>> seq = List.of(seqH36);
-    if (seq.length < T) {
-      final tail = seq.isNotEmpty ? seq.last : List.generate(17, (_) => [0.0, 0.0, 0.0]);
-      while (seq.length < T) {
-        seq.add(_deepCopyFrame(tail));
-      }
-    } else if (seq.length > T) {
-      // take last 243 frames
-      seq = seq.sublist(seq.length - T);
-    }
-
-    // --- 4) Normalize XY to [-1,1], keep conf
-    final Float32List mbIn = Float32List(T * 17 * 3);
-    final double s = (math.min(W, H) / 2.0);
-    final double cx = W / 2.0;
-    final double cy = H / 2.0;
-    int idx = 0;
-    for (int t = 0; t < T; t++) {
-      final fr = seq[t];
-      for (int j = 0; j < 17; j++) {
-        final x = (fr[j][0] - cx) / s;
-        final y = (fr[j][1] - cy) / s;
-        final c = fr[j][2];
-        mbIn[idx++] = x.toDouble();
-        mbIn[idx++] = y.toDouble();
-        mbIn[idx++] = c.toDouble();
-      }
-    }
-
-    // Optional: write mb_input_seq.npy (debug parity)
-    if (writeNpy) {
-      await _writeNpy('${sessionDir.path}/mb_input_seq.npy', mbIn, [T, 17, 3]);
-    }
-
-    // --- 5) Run MotionBERT ONNX
-    final dynamic mb = await OrtManager.fromAsset(modelAssetPath);
-    final Float32List mbInBatched = Float32List(1 * T * 17 * 3)..setAll(0, mbIn);
-    final dynamic out = await _runMb(mb, mbInBatched);
-    final Float32List flat = _asFloat32(out);
-
-    // Expect [1,T,17,3] → flatten length = 1*243*17*3
-    if (flat.length != 1 * T * 17 * 3) {
-      throw StateError('Unexpected MotionBERT output length: ${flat.length}');
-    }
-
-    // Parse to [T][17][3]
-    final List<List<List<double>>> X3D = List.generate(
-      T, (_) => List.generate(17, (_) => List.filled(3, 0.0)),
-    );
-    int p = 0;
-    for (int t = 0; t < T; t++) {
-      for (int j = 0; j < 17; j++) {
-        final x = flat[p++].toDouble();
-        final y = flat[p++].toDouble();
-        final z = flat[p++].toDouble();
-        X3D[t][j][0] = x;
-        X3D[t][j][1] = y;
-        X3D[t][j][2] = z;
-      }
-    }
-
-    // --- 6) Root-relative zeroing (pelvis joint 0)
-    if (rootRelative) {
-      for (int t = 0; t < T; t++) {
-        X3D[t][0][0] = 0.0;
-        X3D[t][0][1] = 0.0;
-        X3D[t][0][2] = 0.0;
-      }
-    }
-
-    // Optional: write mb_output_3d.npy
-    if (writeNpy) {
-      final Float32List outFlat = Float32List(T * 17 * 3);
-      int q = 0;
-      for (int t = 0; t < T; t++) {
-        for (int j = 0; j < 17; j++) {
-          outFlat[q++] = X3D[t][j][0].toDouble();
-          outFlat[q++] = X3D[t][j][1].toDouble();
-          outFlat[q++] = X3D[t][j][2].toDouble();
+    try {
+      // --- 1) Read COCO-17 sequence from jsonl
+      final seqCoco = <List<List<double>>>[]; // [T][17][3]
+      await for (final line in file2D.openRead()
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())) {
+        if (line.trim().isEmpty) continue;
+        final obj = json.decode(line) as Map<String, dynamic>;
+        final kpts = (obj['kpt_coco'] as List)
+            .map<List<double>>((e) => (e as List).map((v) => (v as num).toDouble()).toList())
+            .toList();
+        if (kpts.length == 17) {
+          seqCoco.add(kpts);
         }
       }
-      await _writeNpy('${sessionDir.path}/mb_output_3d.npy', outFlat, [T, 17, 3]);
-    }
+      if (seqCoco.isEmpty) {
+        throw StateError('No frames found in coco_2d.jsonl');
+      }
 
-    // --- 7) Save out_3d.json (compatible with your visualizer)
-    final outJson = {
-      "T": T,
-      "h36m_order": const [
-        "Pelvis","RHip","RKnee","RAnkle","LHip","LKnee","LAnkle",
-        "Spine1","Neck","Head","Site","LShoulder","LElbow","LWrist",
-        "RShoulder","RElbow","RWrist"
-      ],
-      "coords_3d": X3D,
-    };
-    final outFile = File('${sessionDir.path}/out_3d.json');
-    await outFile.writeAsString(const JsonEncoder.withIndent('  ').convert(outJson));
-    return outFile;
+      final int W = frameSize.width.round();
+      final int H = frameSize.height.round();
+
+      // --- 2) COCO-17 → H36M-17 (xy + conf per joint)
+      final seqH36 = <List<List<double>>>[]; // [T][17][3]
+      for (final kpts in seqCoco) {
+        final h36 = _cocoToH36M(kpts);
+        seqH36.add(h36);
+      }
+
+      // --- 3) Pad/trim to 243
+      const int T = 243;
+      List<List<List<double>>> seq = List.of(seqH36);
+      if (seq.length < T) {
+        final tail =
+            seq.isNotEmpty ? seq.last : List.generate(17, (_) => [0.0, 0.0, 0.0]);
+        while (seq.length < T) {
+          seq.add(_deepCopyFrame(tail));
+        }
+      } else if (seq.length > T) {
+        // take last 243 frames
+        seq = seq.sublist(seq.length - T);
+      }
+
+      // --- 4) Normalize XY to [-1,1], keep conf
+      final Float32List mbIn = Float32List(T * 17 * 3);
+      final double s = (math.min(W, H) / 2.0);
+      final double cx = W / 2.0;
+      final double cy = H / 2.0;
+      dbg?.log('MB_PREP', {
+        'sessionId': sessionId,
+        'frames': seqCoco.length,
+        'window': T,
+        'stride': 81,
+        'normalize': {
+          'center': [cx, cy],
+          'scale': s,
+        },
+      });
+      int idx = 0;
+      for (int t = 0; t < T; t++) {
+        final fr = seq[t];
+        for (int j = 0; j < 17; j++) {
+          final x = (fr[j][0] - cx) / s;
+          final y = (fr[j][1] - cy) / s;
+          final c = fr[j][2];
+          mbIn[idx++] = x.toDouble();
+          mbIn[idx++] = y.toDouble();
+          mbIn[idx++] = c.toDouble();
+        }
+      }
+
+      // Optional: write mb_input_seq.npy (debug parity)
+      if (writeNpy) {
+        await _writeNpy('${sessionDir.path}/mb_input_seq.npy', mbIn, [T, 17, 3]);
+      }
+
+      final loadTimer = Stopwatch()..start();
+      final dynamic mb = await OrtManager.fromAsset(modelAssetPath);
+      final double loadMs = loadTimer.elapsedMicroseconds / 1000.0;
+      dbg?.log('MB_EP', {
+        'sessionId': sessionId,
+        'model': modelAssetPath,
+        'providers': ['coreml', 'nnapi', 'xnnpack', 'cpu'],
+        'loadMs': double.parse(loadMs.toStringAsFixed(3)),
+      });
+
+      // --- 5) Run MotionBERT ONNX
+      final Float32List mbInBatched = Float32List(1 * T * 17 * 3)..setAll(0, mbIn);
+      final runTimer = Stopwatch()..start();
+      final dynamic out = await _runMb(mb, mbInBatched);
+      final double runMs = runTimer.elapsedMicroseconds / 1000.0;
+      dbg?.log('MB_RUN', {
+        'sessionId': sessionId,
+        'elapsedMs': double.parse(runMs.toStringAsFixed(3)),
+        'inputShape': [1, T, 17, 3],
+      });
+      final Float32List flat = _asFloat32(out);
+
+      // Expect [1,T,17,3] → flatten length = 1*243*17*3
+      if (flat.length != 1 * T * 17 * 3) {
+        throw StateError('Unexpected MotionBERT output length: ${flat.length}');
+      }
+
+      // Parse to [T][17][3]
+      final List<List<List<double>>> X3D = List.generate(
+        T, (_) => List.generate(17, (_) => List.filled(3, 0.0)),
+      );
+      double zMin = double.infinity;
+      double zMax = -double.infinity;
+      int p = 0;
+      for (int t = 0; t < T; t++) {
+        for (int j = 0; j < 17; j++) {
+          final x = flat[p++].toDouble();
+          final y = flat[p++].toDouble();
+          final z = flat[p++].toDouble();
+          X3D[t][j][0] = x;
+          X3D[t][j][1] = y;
+          X3D[t][j][2] = z;
+          zMin = math.min(zMin, z);
+          zMax = math.max(zMax, z);
+        }
+      }
+
+      // --- 6) Root-relative zeroing (pelvis joint 0)
+      if (rootRelative) {
+        for (int t = 0; t < T; t++) {
+          X3D[t][0][0] = 0.0;
+          X3D[t][0][1] = 0.0;
+          X3D[t][0][2] = 0.0;
+        }
+      }
+
+      dbg?.log('MB_OUT', {
+        'sessionId': sessionId,
+        'frames': T,
+        'z_min': double.parse(zMin.toStringAsFixed(4)),
+        'z_max': double.parse(zMax.toStringAsFixed(4)),
+      });
+
+      if (dbg != null && dbg.enabled) {
+        final stats = {
+          'frames_2d': seqCoco.length,
+          'window': T,
+          'stride': 81,
+          'z_min': zMin,
+          'z_max': zMax,
+        };
+        await dbg.saveText(
+          'mb_quick_stats.json',
+          const JsonEncoder.withIndent('  ').convert(stats),
+        );
+      }
+
+      // Optional: write mb_output_3d.npy
+      if (writeNpy) {
+        final Float32List outFlat = Float32List(T * 17 * 3);
+        int q = 0;
+        for (int t = 0; t < T; t++) {
+          for (int j = 0; j < 17; j++) {
+            outFlat[q++] = X3D[t][j][0].toDouble();
+            outFlat[q++] = X3D[t][j][1].toDouble();
+            outFlat[q++] = X3D[t][j][2].toDouble();
+          }
+        }
+        await _writeNpy('${sessionDir.path}/mb_output_3d.npy', outFlat, [T, 17, 3]);
+      }
+
+      // --- 7) Save out_3d.json (compatible with your visualizer)
+      final outJson = {
+        "T": T,
+        "h36m_order": const [
+          "Pelvis","RHip","RKnee","RAnkle","LHip","LKnee","LAnkle",
+          "Spine1","Neck","Head","Site","LShoulder","LElbow","LWrist",
+          "RShoulder","RElbow","RWrist"
+        ],
+        "coords_3d": X3D,
+      };
+      final outFile = File('${sessionDir.path}/out_3d.json');
+      await outFile.writeAsString(const JsonEncoder.withIndent('  ').convert(outJson));
+      dbg?.log('MB_OUT_FILE', {
+        'sessionId': sessionId,
+        'path': outFile.path,
+      });
+      return outFile;
+    } finally {
+      await dbg?.close();
+    }
   }
 
   // ---------- helpers ----------

--- a/lib/shared/services/pipeline_debug_recorder.dart
+++ b/lib/shared/services/pipeline_debug_recorder.dart
@@ -1,0 +1,75 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:image/image.dart' as img;
+
+class PipelineDebugRecorder {
+  PipelineDebugRecorder({
+    required this.enabled,
+    required this.sessionId,
+    required Directory sessionDir,
+    String logFileName = 'debug_log.jsonl',
+  })  : _sessionDir = sessionDir,
+        _sink = enabled
+            ? File('${sessionDir.path}/$logFileName')
+                .openWrite(mode: FileMode.append)
+            : null;
+
+  final bool enabled;
+  final String sessionId;
+  final Directory _sessionDir;
+  final IOSink? _sink;
+  final Map<String, int> _stageLastFrame = <String, int>{};
+  bool _closed = false;
+
+  Directory get sessionDir => _sessionDir;
+
+  void log(String tag, Map<String, dynamic> payload) {
+    if (!enabled || _closed) return;
+    final record = <String, dynamic>{'tag': tag, ...payload};
+    final line = json.encode(record);
+    if (kDebugMode) {
+      debugPrint(line);
+    } else {
+      // ignore: avoid_print
+      print(line);
+    }
+    _sink?.writeln(line);
+  }
+
+  bool shouldLog(String tag, int frameIndex,
+      {int every = 30, int first = 5}) {
+    if (!enabled) return false;
+    if (frameIndex < first) return true;
+    if (every <= 0) return true;
+    final last = _stageLastFrame[tag];
+    if (last == null || frameIndex - last >= every) {
+      _stageLastFrame[tag] = frameIndex;
+      return true;
+    }
+    return false;
+  }
+
+  Future<void> saveImage(String name, img.Image image,
+      {int quality = 90}) async {
+    if (!enabled || _closed) return;
+    final File out = File('${_sessionDir.path}/$name');
+    final bytes = img.encodeJpg(image, quality: quality);
+    await out.writeAsBytes(bytes, flush: true);
+  }
+
+  Future<void> saveText(String name, String contents) async {
+    if (!enabled || _closed) return;
+    final File out = File('${_sessionDir.path}/$name');
+    await out.writeAsString(contents, flush: true);
+  }
+
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    await _sink?.flush();
+    await _sink?.close();
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable pipeline debug recorder that writes structured JSON logs and artifacts into the session folder
- instrument the live 2D pipeline with per-stage timing, logging, and overlay captures when debug mode is enabled
- extend the MotionBert runner to emit MotionBERT prep/run/output diagnostics and quick stats artifacts

## Testing
- not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68e29f36f964832fa4f2a77811c7045a