### PR TITLE
Silence non-pipeline logs and add pose IO tracing

### DIFF
--- a/lib/screens/exercise_preview_screen.dart
+++ b/lib/screens/exercise_preview_screen.dart
@@ -12,7 +12,7 @@ import 'dart:ui';
 import 'package:amplify_auth_cognito/amplify_auth_cognito.dart';
 import 'package:amplify_flutter/amplify_flutter.dart' as amp;
 import 'package:camera/camera.dart';
-import 'package:flutter/foundation.dart' show Listenable, kDebugMode;
+import 'package:flutter/foundation.dart' show Listenable, kDebugMode, debugPrint;
 import 'package:flutter/material.dart';
 import 'package:flutter/painting.dart' show applyBoxFit;
 import 'package:flutter/services.dart';
@@ -35,6 +35,13 @@ import '../shared/services/video_transcoder.dart'; // 10fps helper
 import '../shared/widgets/live_skeleton_overlay.dart';
 import '../shared/widgets/processing_banner.dart';
 import 'package:fit_perfect_v2/shared/services/live_pose.dart';
+
+const bool _enableExercisePreviewLogs = false;
+
+void _exercisePreviewLog(String message) {
+  if (!_enableExercisePreviewLogs) return;
+  debugPrint(message);
+}
 
 class ExercisePreviewScreen extends StatefulWidget {
   const ExercisePreviewScreen({super.key, required this.exerciseId});
@@ -194,12 +201,14 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
       await _matcher.ensureLoaded();
       _refReady = _matcher.refPoints != null;
       if (kDebugMode) {
-        debugPrint('[ExercisePreview] reference loaded: $_refReady '
+        _exercisePreviewLog('[ExercisePreview] reference loaded: $_refReady '
             '(kpts=${_matcher.refPoints?.length ?? 0}, '
             'source=${_matcher.refSource ?? 'unknown'})');
       }
     } catch (e) {
-      if (kDebugMode) debugPrint('[ExercisePreview] ensureLoaded error: $e');
+      if (kDebugMode) {
+        _exercisePreviewLog('[ExercisePreview] ensureLoaded error: $e');
+      }
     }
 
     await _initCamera();
@@ -316,7 +325,9 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
       };
       _cocoSink!.writeln(jsonEncode(frame));
     } catch (e) {
-      if (kDebugMode) debugPrint('appendCocoFrame failed: $e');
+      if (kDebugMode) {
+        _exercisePreviewLog('appendCocoFrame failed: $e');
+      }
     }
   }
 
@@ -381,7 +392,7 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
       if (!mounted) return;
       if (ok != _poseOk) {
         if (kDebugMode && _logPoseEvents) {
-          debugPrint('MAE(px) = ${_lastMaePx?.toStringAsFixed(1)}; ok=$ok');
+          _exercisePreviewLog('MAE(px) = ${_lastMaePx?.toStringAsFixed(1)}; ok=$ok');
         }
         setState(() {
           _poseOk = ok;
@@ -399,7 +410,7 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
         _updateCalibrationHold();
       }
       if (kDebugMode && _logPoseEvents) {
-        debugPrint('live 2D pose failed: $e');
+        _exercisePreviewLog('live 2D pose failed: $e');
       }
     } finally {
       _runningEst = false;
@@ -428,7 +439,7 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
     if (kDebugMode && _logPoseEvents) {
       final refSrc = _matcher.refSource ?? 'unknown';
       final maeLabel = mae.isFinite ? mae.toStringAsFixed(2) : mae.toString();
-      debugPrint('[PoseMatch] maePx=$maeLabel, match=$ok, '
+      _exercisePreviewLog('[PoseMatch] maePx=$maeLabel, match=$ok, '
           'reference=$refSrc, liveSpace=${w}x$h (raw camera)');
     }
 
@@ -622,7 +633,7 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
       );
     } catch (e) {
       _hideProcessingDialog();
-      debugPrint('[ExercisePreview] offline analyze failed → $e');
+      _exercisePreviewLog('[ExercisePreview] offline analyze failed → $e');
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Offline analysis failed: $e')),
@@ -774,7 +785,7 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
         subject: 'Live 2D RTM-Pose export',
       );
     } catch (e) {
-      debugPrint('Share error: $e');
+      _exercisePreviewLog('Share error: $e');
     }
   }
 
@@ -1331,12 +1342,12 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
       );
 
       if (resp.statusCode == 202) {
-        debugPrint('✅ backend accepted enqueue');
+        _exercisePreviewLog('✅ backend accepted enqueue');
       } else {
-        debugPrint('⚠️ backend ${resp.statusCode}: ${resp.body}');
+        _exercisePreviewLog('⚠️ backend ${resp.statusCode}: ${resp.body}');
       }
     } catch (e) {
-      debugPrint('⚠️ could not reach backend: $e');
+      _exercisePreviewLog('⚠️ could not reach backend: $e');
     }
   }
 

--- a/lib/screens/progress_screen.dart
+++ b/lib/screens/progress_screen.dart
@@ -1,5 +1,6 @@
 // lib/screens/progress_screen.dart
 import 'dart:math' as math;
+import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:go_router/go_router.dart';
@@ -14,6 +15,13 @@ import 'package:share_plus/share_plus.dart';
 /// • No extra packages required. Calendar is a custom month grid w/ heat-map.
 /// • All data is mocked; replace the *_DAO calls with your repos later.
 /// • Analytics hooks: debugPrint events for tab change, day taps, filters.
+
+const bool _enableProgressScreenLogs = false;
+
+void _progressLog(String message) {
+  if (!_enableProgressScreenLogs) return;
+  debugPrint(message);
+}
 
 class ProgressScreen extends StatefulWidget {
   const ProgressScreen({super.key});
@@ -66,7 +74,7 @@ class _ProgressScreenState extends State<ProgressScreen>
     _tab = TabController(length: 3, vsync: this);
     _tab.addListener(() {
       if (_tab.indexIsChanging) return;
-      debugPrint('analytics: progress_tab_view tab=${_tab.index}');
+      _progressLog('analytics: progress_tab_view tab=${_tab.index}');
     });
   }
 
@@ -135,7 +143,7 @@ class _ProgressScreenState extends State<ProgressScreen>
           _CalendarTab(
             sessions: _sessions,
             onDayTap: (day, sessions) {
-              debugPrint('analytics: calendar_day_tap date=$day has=${sessions.isNotEmpty}');
+              _progressLog('analytics: calendar_day_tap date=$day has=${sessions.isNotEmpty}');
               _CalendarBottomSheet.show(context, day, sessions);
             },
             onDayLongPress: _jumpHistoryTo,
@@ -837,7 +845,7 @@ class _HistoryListState extends State<_HistoryList> {
                 builder: (_) => _FilterSheet(),
               );
               if (res != null) {
-                debugPrint('analytics: history_filter_apply ${res.toJson()}');
+                _progressLog('analytics: history_filter_apply ${res.toJson()}');
                 // In real app, apply filters to repository and refresh list.
                 if (mounted) {
                   ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/shared/providers/auth_provider.dart
+++ b/lib/shared/providers/auth_provider.dart
@@ -9,6 +9,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 enum AuthStatus { unknown, unauthenticated, awaitingCode, authenticated, error }
 
+const bool _enableAuthLogs = false;
+
+void _authLog(
+  String message, {
+  Object? error,
+  StackTrace? stackTrace,
+}) {
+  if (!_enableAuthLogs) return;
+  dev.log(message, error: error, stackTrace: stackTrace);
+}
+
 class AuthState {
   final AuthStatus status;
   final String? email;
@@ -24,7 +35,7 @@ class AuthState {
 class AuthNotifier extends StateNotifier<AuthState> {
   AuthNotifier() : super(const AuthState.unknown()) {
     _hubSub = Amplify.Hub.listen(HubChannel.Auth, (e) {
-      dev.log('Hub[Auth]: ${e.eventName}  payload=${e.payload}');
+      _authLog('Hub[Auth]: ${e.eventName}  payload=${e.payload}');
     });
     _checkLoginStatus();
   }
@@ -42,20 +53,20 @@ class AuthNotifier extends StateNotifier<AuthState> {
 
   Future<void> _checkLoginStatus() async {
     try {
-      dev.log('Auth: fetchAuthSession…');
+      _authLog('Auth: fetchAuthSession…');
       final session = await Amplify.Auth.fetchAuthSession();
-      dev.log('Auth: isSignedIn=${session.isSignedIn}');
+      _authLog('Auth: isSignedIn=${session.isSignedIn}');
       state = session.isSignedIn ? const AuthState.authenticated()
                                  : const AuthState.unauthenticated();
     } on AuthException catch (e, st) {
-      dev.log('Auth: fetchAuthSession ERROR: ${e.message}', stackTrace: st);
+      _authLog('Auth: fetchAuthSession ERROR: ${e.message}', stackTrace: st);
       state = AuthState.error(e.message);
     }
   }
 
   Future<void> signUp({required String email, required String password}) async {
     try {
-      dev.log('Auth: signUp($email)…');
+      _authLog('Auth: signUp($email)…');
       await Amplify.Auth.signUp(
         username: email,
         password: password,
@@ -63,45 +74,45 @@ class AuthNotifier extends StateNotifier<AuthState> {
       );
       state = AuthState.awaitingCode(email);
     } on AuthException catch (e, st) {
-      dev.log('Auth: signUp ERROR: ${e.message}', stackTrace: st);
+      _authLog('Auth: signUp ERROR: ${e.message}', stackTrace: st);
       state = AuthState.error(e.message);
     }
   }
 
   Future<void> confirmCode({required String email, required String code}) async {
     try {
-      dev.log('Auth: confirmSignUp($email)…');
+      _authLog('Auth: confirmSignUp($email)…');
       final res = await Amplify.Auth.confirmSignUp(username: email, confirmationCode: code);
-      dev.log('Auth: confirmSignUp → isSignUpComplete=${res.isSignUpComplete}');
+      _authLog('Auth: confirmSignUp → isSignUpComplete=${res.isSignUpComplete}');
       if (res.isSignUpComplete) {
         await signIn(email: email, password: null);
       } else {
         state = const AuthState.unauthenticated();
       }
     } on AuthException catch (e, st) {
-      dev.log('Auth: confirmSignUp ERROR: ${e.message}', stackTrace: st);
+      _authLog('Auth: confirmSignUp ERROR: ${e.message}', stackTrace: st);
       state = AuthState.error(e.message);
     }
   }
 
   Future<void> signIn({required String email, required String? password}) async {
     try {
-      dev.log('Auth: signIn($email)…');
+      _authLog('Auth: signIn($email)…');
       await Amplify.Auth.signIn(username: email, password: password);
       await _checkLoginStatus();
     } on AuthException catch (e, st) {
-      dev.log('Auth: signIn ERROR: ${e.message}', stackTrace: st);
+      _authLog('Auth: signIn ERROR: ${e.message}', stackTrace: st);
       state = AuthState.error(e.message);
     }
   }
 
   Future<void> signOut() async {
     try {
-      dev.log('Auth: signOut(global)…');
+      _authLog('Auth: signOut(global)…');
       await Amplify.Auth.signOut(options: const SignOutOptions(globalSignOut: true));
       await _checkLoginStatus();
     } on AuthException catch (e, st) {
-      dev.log('Auth: signOut ERROR: ${e.message}', stackTrace: st);
+      _authLog('Auth: signOut ERROR: ${e.message}', stackTrace: st);
       state = AuthState.error(e.message);
     }
   }
@@ -109,11 +120,11 @@ class AuthNotifier extends StateNotifier<AuthState> {
   /// Google / Facebook via Hosted UI
   Future<void> signInWithProvider(AuthProvider provider) async {
     if (_webUiInFlight) {
-      dev.log('HostedUI: sign-in ignored (already in flight)');
+      _authLog('HostedUI: sign-in ignored (already in flight)');
       return;
     }
     _webUiInFlight = true;
-    dev.log('HostedUI: start → $provider');
+    _authLog('HostedUI: start → $provider');
     try {
       final opts = SignInWithWebUIOptions(
         pluginOptions: const CognitoSignInWithWebUIPluginOptions(
@@ -121,12 +132,12 @@ class AuthNotifier extends StateNotifier<AuthState> {
         ),
       );
       final res = await Amplify.Auth.signInWithWebUI(provider: provider, options: opts);
-      dev.log('HostedUI: result → nextStep=${res.nextStep.signInStep} isSignedIn=${res.isSignedIn}');
+      _authLog('HostedUI: result → nextStep=${res.nextStep.signInStep} isSignedIn=${res.isSignedIn}');
       await _checkLoginStatus();
     } on AuthException catch (e, st) {
-      dev.log('HostedUI: ERROR: ${e.runtimeType}: ${e.message}', stackTrace: st);
+      _authLog('HostedUI: ERROR: ${e.runtimeType}: ${e.message}', stackTrace: st);
       if (e.message.toLowerCase().contains('cancel')) {
-        dev.log('Hint: iOS reported cancel. Check Info.plist URL scheme, '
+        _authLog('Hint: iOS reported cancel. Check Info.plist URL scheme, '
             'Cognito callback (com.fitperfect://auth), and ensure only one session is launched.');
       }
       state = AuthState.error(e.message);
@@ -139,7 +150,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
   Future<void> signInHostedUI() async {
     if (_webUiInFlight) return;
     _webUiInFlight = true;
-    dev.log('HostedUI (no provider): start');
+    _authLog('HostedUI (no provider): start');
     try {
       final opts = SignInWithWebUIOptions(
         pluginOptions: const CognitoSignInWithWebUIPluginOptions(
@@ -147,11 +158,11 @@ class AuthNotifier extends StateNotifier<AuthState> {
         ),
       );
       final res = await Amplify.Auth.signInWithWebUI(options: opts);
-      dev.log('HostedUI (no provider): result → nextStep=${res.nextStep.signInStep} '
+      _authLog('HostedUI (no provider): result → nextStep=${res.nextStep.signInStep} '
           'isSignedIn=${res.isSignedIn}');
       await _checkLoginStatus();
     } on AuthException catch (e, st) {
-      dev.log('HostedUI (no provider): ERROR: ${e.message}', stackTrace: st);
+      _authLog('HostedUI (no provider): ERROR: ${e.message}', stackTrace: st);
       state = AuthState.error(e.message);
     } finally {
       _webUiInFlight = false;
@@ -169,7 +180,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
         '$domain/oauth2/authorize?identity_provider=${provider.name}'
         '&redirect_uri=${Uri.encodeComponent(redirect)}'
         '&response_type=code&client_id=$clientId&scope=$scope';
-    dev.log('HostedUI TEST URL → $url');
+    _authLog('HostedUI TEST URL → $url');
   }
 }
 

--- a/lib/shared/services/api_client.dart
+++ b/lib/shared/services/api_client.dart
@@ -10,6 +10,13 @@ import 'package:flutter/foundation.dart';                       //  debugPrint
 import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';              //  offline copy
 
+const bool _enableApiClientLogs = false;
+
+void _apiClientLog(String message) {
+  if (!_enableApiClientLogs) return;
+  debugPrint(message);
+}
+
 /// Central place for all calls to the Flask analyzer API.
 class ApiClient {
   /// Public URL of your Flask service – change if you put it behind a proxy.
@@ -88,14 +95,14 @@ class ApiClient {
     );
 
     for (var attempt = 0; attempt < max; attempt++) {
-      debugPrint('[ApiClient] poll #${attempt + 1} → $resultUrl');
+      _apiClientLog('[ApiClient] poll #${attempt + 1} → $resultUrl');
 
       // 1  obtain a *fresh* JWT
       late final String jwt;
       try {
         jwt = await _freshJwt();
       } on AuthException catch (e) {
-        debugPrint('[ApiClient] token refresh failed → $e; retrying…');
+        _apiClientLog('[ApiClient] token refresh failed → $e; retrying…');
         await Future.delayed(const Duration(seconds: 2));
         continue;                              // next loop iteration
       }
@@ -106,7 +113,7 @@ class ApiClient {
         headers: {'Authorization': 'Bearer $jwt'},
       );
 
-      debugPrint('[ApiClient]  ↳ ${resp.statusCode}  ${resp.body}');
+      _apiClientLog('[ApiClient]  ↳ ${resp.statusCode}  ${resp.body}');
 
       /* 2.a READY ─────────────────────────────────────────────── */
       if (resp.statusCode == 200) {
@@ -115,11 +122,11 @@ class ApiClient {
           throw StateError('Missing signed URL in 200 response');
         }
 
-        debugPrint('[ApiClient] presigned URL received – downloading…');
+        _apiClientLog('[ApiClient] presigned URL received – downloading…');
 
         /* ── 3. Download the report itself ──────────────────── */
         final reportResp = await http.get(Uri.parse(signed));
-        debugPrint('[ApiClient]      download '
+        _apiClientLog('[ApiClient]      download '
             '${reportResp.statusCode}  '
             '${reportResp.contentLength ?? reportResp.bodyBytes.length} bytes');
 
@@ -133,9 +140,9 @@ class ApiClient {
             final fileName = s3Key.replaceAll('/', '_') + '.json';
             final file     = File('${dir.path}/$fileName');
             await file.writeAsString(jsonStr, flush: true);
-            debugPrint('[ApiClient] saved to ${file.path}');
+            _apiClientLog('[ApiClient] saved to ${file.path}');
           } catch (e) {
-            debugPrint('[ApiClient] could not save report locally: $e');
+            _apiClientLog('[ApiClient] could not save report locally: $e');
           }
 
           return decoded is List ? {'data': decoded} : decoded;

--- a/lib/shared/services/live_pose.dart
+++ b/lib/shared/services/live_pose.dart
@@ -24,6 +24,7 @@ import 'dart:typed_data';
 import 'dart:ui' show Offset; // for overlay points
 
 import 'package:camera/camera.dart';
+import 'package:flutter/foundation.dart';
 import 'package:image/image.dart' as img;
 import 'package:path_provider/path_provider.dart';
 
@@ -110,6 +111,7 @@ class LivePoseEngine {
     }
     _jsonlPath = '${_sessionDir.path}/coco_2d.jsonl';
     _jsonlSink = File(_jsonlPath).openWrite(mode: FileMode.append);
+    debugPrint('[2D] Writing to $_jsonlPath');
 
     _debugger = debug
         ? PipelineDebugRecorder(

--- a/lib/shared/services/motionbert_runner.dart
+++ b/lib/shared/services/motionbert_runner.dart
@@ -25,6 +25,7 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' show Size;
 
+import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart';
 
 import 'ort_session.dart'; // OrtManager.fromAsset(...)
@@ -74,10 +75,18 @@ class MotionBertRunner {
       'model': modelAssetPath,
     });
 
-    final file2D = File('${sessionDir.path}/coco_2d.jsonl');
+    final default2DPath = '${sessionDir.path}/coco_2d.jsonl';
+    File file2D = File(default2DPath);
     if (!await file2D.exists()) {
-      throw StateError('Missing coco_2d.jsonl at ${file2D.path}');
+      final legacy = File('${docs.path}/FitPerfect/poses/$sessionId/2d/frames.jsonl');
+      debugPrint('[3D] Trying legacy ${legacy.path}');
+      if (await legacy.exists()) {
+        file2D = legacy;
+      } else {
+        throw StateError('Missing coco_2d.jsonl at $default2DPath');
+      }
     }
+    debugPrint('[3D] Reading 2D from ${file2D.path}');
 
     try {
       // --- 1) Read COCO-17 sequence from jsonl

--- a/lib/shared/services/pose_matcher.dart
+++ b/lib/shared/services/pose_matcher.dart
@@ -35,6 +35,13 @@ import 'dart:ui';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
+const bool _enablePoseMatcherLogs = false;
+
+void _poseMatcherLog(String message) {
+  if (!_enablePoseMatcherLogs) return;
+  debugPrint(message);
+}
+
 class PoseMatcher {
   PoseMatcher({
     this.fixedMaeThresholdPx = 30.0, // absolute pixel cap
@@ -101,12 +108,12 @@ class PoseMatcher {
       _ref17 = _heuristicToCoco17(_ref17!);
       _refBBoxH = _bboxHeight(_ref17!);
       if (kDebugMode) {
-        debugPrint('[PoseMatcher] Loaded reference with ${_ref17!.length} kpts '
+        _poseMatcherLog('[PoseMatcher] Loaded reference with ${_ref17!.length} kpts '
             'from ${_refSource ?? 'unknown'} (refBBoxH=${_refBBoxH?.toStringAsFixed(1)})');
       }
     } else {
       if (kDebugMode) {
-        debugPrint('[PoseMatcher] Could not load reference from assets/meta/. '
+        _poseMatcherLog('[PoseMatcher] Could not load reference from assets/meta/. '
             'Ensure a JSON at assets/meta/reference_frame.json is listed in pubspec.');
       }
     }
@@ -276,7 +283,7 @@ class PoseMatcher {
       return null;
     } catch (e) {
       if (kDebugMode) {
-        debugPrint('[PoseMatcher] JSON load failed for "$assetPath": $e');
+        _poseMatcherLog('[PoseMatcher] JSON load failed for "$assetPath": $e');
       }
       return null;
     }

--- a/lib/shared/services/pose_runtime.dart
+++ b/lib/shared/services/pose_runtime.dart
@@ -11,6 +11,13 @@ import 'ort_session.dart';
 import 'tensor_utils.dart';
 import 'video_sampler.dart';
 
+const bool _enablePoseRuntimeLogs = false;
+
+void _poseRuntimeLog(String message) {
+  if (!_enablePoseRuntimeLogs) return;
+  debugPrint(message);
+}
+
 /// Callback emitted from the offline pipeline when 3D progress changes.
 typedef PosePipelineProgressCallback = void Function(PosePipelineProgress progress);
 
@@ -227,7 +234,7 @@ class PosePipeline {
         break;
       } catch (e) {
         if (kDebugMode) {
-          debugPrint('[PosePipeline] Could not load ${cfg.assetPath}: $e');
+          _poseRuntimeLog('[PosePipeline] Could not load ${cfg.assetPath}: $e');
         }
         continue;
       }

--- a/lib/shared/services/summary_repository.dart
+++ b/lib/shared/services/summary_repository.dart
@@ -7,6 +7,13 @@ import 'package:http/http.dart' as http;
 
 import 'api_client.dart';
 
+const bool _enableSummaryRepositoryLogs = false;
+
+void _summaryRepoLog(String message) {
+  if (!_enableSummaryRepositoryLogs) return;
+  debugPrint(message);
+}
+
 class SummaryRepository {
   /// Order:
   /// 1) Try backend summary (when s3Key provided)
@@ -22,7 +29,7 @@ class SummaryRepository {
       try {
         return await ApiClient.fetchSummary(s3Key);
       } catch (e) {
-        debugPrint('[SummaryRepository] server summary failed: $e');
+        _summaryRepoLog('[SummaryRepository] server summary failed: $e');
       }
     }
 
@@ -38,7 +45,7 @@ class SummaryRepository {
             await rootBundle.loadString('assets/fixtures/summary_$exerciseId.json');
         return jsonDecode(str) as Map<String, dynamic>;
       } catch (e) {
-        debugPrint('[SummaryRepository] missing fixture for $exerciseId: $e');
+        _summaryRepoLog('[SummaryRepository] missing fixture for $exerciseId: $e');
       }
     }
 

--- a/lib/shared/services/video_transcoder.dart
+++ b/lib/shared/services/video_transcoder.dart
@@ -6,6 +6,13 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:ffmpeg_kit_flutter_new/ffmpeg_kit.dart';
 
+const bool _enableVideoTranscoderLogs = false;
+
+void _videoTranscoderLog(String message) {
+  if (!_enableVideoTranscoderLogs) return;
+  debugPrint(message);
+}
+
 class VideoTranscoder {
   /// Creates a 10-fps, square-padded surrogate MP4 without touching [src].
   /// Output is centered inside 640×640, AR preserved, even dimensions enforced.
@@ -45,17 +52,17 @@ class VideoTranscoder {
       _q(outPath),
     ].join(' ');
 
-    debugPrint('[VideoTranscoder] running ffmpeg: $cmd');
+    _videoTranscoderLog('[VideoTranscoder] running ffmpeg: $cmd');
     final session = await FFmpegKit.execute(cmd);
     final rc = await session.getReturnCode();
 
     if (rc?.isValueSuccess() != true) {
       final logs = await session.getAllLogsAsString();
-      debugPrint('[VideoTranscoder] ffmpeg failed rc=$rc\n$logs');
+      _videoTranscoderLog('[VideoTranscoder] ffmpeg failed rc=$rc\n$logs');
       throw Exception('FFmpeg failed: $rc');
     }
 
-    debugPrint('[VideoTranscoder] created $outPath');
+    _videoTranscoderLog('[VideoTranscoder] created $outPath');
     return File(outPath);
   }
 


### PR DESCRIPTION
## Summary
- gate Amplify, analytics, and helper service logs behind disabled flags so only pose pipeline output reaches the console
- add explicit 2D writer and 3D reader log lines, including a legacy 2D fallback path for MotionBert

## Testing
- not run (Flutter and Dart tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68e2bf9a21d4832f99373e8833459965