### PR TITLE
Improve 3D session path discovery

### DIFF
--- a/lib/screens/feedback_screen.dart
+++ b/lib/screens/feedback_screen.dart
@@ -1,15 +1,16 @@
 // lib/screens/feedback_screen.dart
 // ─────────────────────────────────────────────────────────
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'package:flutter/material.dart';
-import 'package:video_player/video_player.dart';
-import 'package:go_router/go_router.dart';
-
-
 import 'dart:ui' show Size;
-import 'package:path_provider/path_provider.dart';
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:video_player/video_player.dart';
+
 import 'package:fit_perfect_v2/shared/services/pose_processing_controller.dart';
+import 'package:fit_perfect_v2/shared/utils/session_storage.dart';
 class FeedbackScreen extends StatefulWidget {
   const FeedbackScreen({
     super.key,
@@ -143,6 +144,7 @@ class _FeedbackScreenState extends State<FeedbackScreen> {
     super.initState();
 
     _events = _parseReport(widget.report);
+    _hydrateReportMetadata(widget.report);
 
     if (widget.videoPath != null) {
       _vc = VideoPlayerController.file(File(widget.videoPath!))
@@ -173,12 +175,160 @@ class _FeedbackScreenState extends State<FeedbackScreen> {
     _vc.addListener(() {
       if (mounted) setState(() {});
     });
+
+    unawaited(_bootstrap3DState());
   }
 
   @override
   void dispose() {
     _vc.dispose();
     super.dispose();
+  }
+
+  void _hydrateReportMetadata(Map<String, dynamic> report) {
+    _sessionId = _extractSessionId(report) ?? _sessionIdFromVideoKey();
+    final out3d = _extractOut3dPath(report);
+    if (out3d != null && out3d.isNotEmpty) {
+      _out3dPath = out3d;
+    }
+  }
+
+  Future<void> _bootstrap3DState() async {
+    if (_out3dPath != null && _out3dPath!.isNotEmpty) {
+      await _load3D(_out3dPath!);
+      return;
+    }
+
+    final sid = _sessionId;
+    if (sid == null || sid.isEmpty) {
+      return;
+    }
+
+    final existingOut = await SessionStorage.findSessionFile(sid, 'out_3d.json');
+    if (existingOut != null) {
+      if (mounted) {
+        setState(() => _out3dPath = existingOut.path);
+      } else {
+        _out3dPath = existingOut.path;
+      }
+      await _load3D(existingOut.path);
+    } else {
+      await _loadLogTail();
+    }
+  }
+
+  String? _extractSessionId(Map<String, dynamic> report) {
+    const keys = ['sessionId', 'session_id', 'session', 'session-id', 'sessionID'];
+    String? fromRoot = _lookupString(report, keys);
+    if (fromRoot != null && fromRoot.isNotEmpty) {
+      return fromRoot;
+    }
+
+    final meta = report['meta'];
+    if (meta is Map<String, dynamic>) {
+      final fromMeta = _lookupString(meta, keys);
+      if (fromMeta != null && fromMeta.isNotEmpty) {
+        return fromMeta;
+      }
+    }
+
+    final data = report['data'];
+    if (data is List) {
+      for (final row in data) {
+        if (row is Map<String, dynamic>) {
+          final candidate = _lookupString(row, keys);
+          if (candidate != null && candidate.isNotEmpty) {
+            return candidate;
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  String? _extractOut3dPath(Map<String, dynamic> report) {
+    const keys = ['out3dPath', 'out_3d_path', 'out_3d', 'out3d', 'out3DPath'];
+    String? path = _lookupString(report, keys);
+    if (path != null && path.isNotEmpty) {
+      return path;
+    }
+
+    final meta = report['meta'];
+    if (meta is Map<String, dynamic>) {
+      final metaPath = _lookupString(meta, keys);
+      if (metaPath != null && metaPath.isNotEmpty) {
+        return metaPath;
+      }
+    }
+
+    final out3d = report['out3d'];
+    if (out3d is Map<String, dynamic>) {
+      final nested = _lookupString(out3d, const ['path', 'file', 'uri']);
+      if (nested != null && nested.isNotEmpty) {
+        return nested;
+      }
+    }
+
+    return null;
+  }
+
+  String? _lookupString(Map<String, dynamic> source, List<String> keys) {
+    for (final key in keys) {
+      final value = source[key];
+      final str = _valueToString(value);
+      if (str != null && str.isNotEmpty) {
+        return str;
+      }
+    }
+    return null;
+  }
+
+  String? _valueToString(dynamic value) {
+    if (value == null) return null;
+    if (value is String) {
+      final trimmed = value.trim();
+      return trimmed.isEmpty ? null : trimmed;
+    }
+    if (value is num || value is bool) {
+      return value.toString();
+    }
+    return null;
+  }
+
+  String? _sessionIdFromVideoKey() {
+    final key = widget.videoKey;
+    if (key == null || key.isEmpty) {
+      return null;
+    }
+
+    final normalized = key.replaceAll('\\', '/');
+    final parts = normalized.split('/');
+    if (parts.isEmpty) {
+      return null;
+    }
+
+    final isLocal = parts.first == 'local';
+    final isPrivateVideo =
+        parts.length >= 4 && parts[0] == 'private' && parts[1] == 'videos';
+    if (!isLocal && !isPrivateVideo) {
+      return null;
+    }
+
+    String file = '';
+    for (var i = parts.length - 1; i >= 0; i--) {
+      if (parts[i].isNotEmpty) {
+        file = parts[i];
+        break;
+      }
+    }
+
+    if (file.isEmpty) {
+      return null;
+    }
+
+    final dot = file.lastIndexOf('.');
+    final stem = dot > 0 ? file.substring(0, dot) : file;
+    return stem.isNotEmpty ? stem : null;
   }
 
   /* ─────────────────── SHOW TECHNIQUE ANIMATION ────────────────── */
@@ -324,18 +474,19 @@ class _FeedbackScreenState extends State<FeedbackScreen> {
     final sid = _sessionId;
     if (sid == null) return;
     try {
-      final docs = await getApplicationDocumentsDirectory();
-      final dir = Directory('\${docs.path}/FitPerfect/\$sid');
-      final file = File('\${dir.path}/coco_2d.jsonl');
-      if (!file.existsSync()) {
+      final file = await SessionStorage.findSessionFile(sid, 'coco_2d.jsonl');
+      if (file == null) {
+        if (!mounted) return;
         setState(() => _logTail = const ['(no coco_2d.jsonl found yet)']);
         return;
       }
       final lines = await file.readAsLines();
       final take = lines.length >= 10 ? lines.sublist(lines.length - 10) : lines;
+      if (!mounted) return;
       setState(() => _logTail = take);
     } catch (e) {
-      setState(() => _logTail = ['(could not read logs: \$e)']);
+      if (!mounted) return;
+      setState(() => _logTail = ['(could not read logs: $e)']);
     }
   }
 
@@ -377,10 +528,8 @@ class _FeedbackScreenState extends State<FeedbackScreen> {
     if (sid == null) return;
     setState(() { _retrying3D = true; _mbError = null; });
     try {
-      final docs = await getApplicationDocumentsDirectory();
-      final dir = Directory('\${docs.path}/FitPerfect/\$sid');
-      final file = File('\${dir.path}/coco_2d.jsonl');
-      if (!file.existsSync()) throw 'coco_2d.jsonl missing in \$sid';
+      final file = await SessionStorage.findSessionFile(sid, 'coco_2d.jsonl');
+      if (file == null) throw 'coco_2d.jsonl missing in $sid';
       final lines = await file.readAsLines();
       int w = 640, h = 480;
       for (final ln in lines) {
@@ -401,7 +550,8 @@ class _FeedbackScreenState extends State<FeedbackScreen> {
         throw '3D run returned null';
       }
     } catch (e) {
-      setState(() { _mbError = 'Retry failed: \$e'; });
+      if (!mounted) return;
+      setState(() { _mbError = 'Retry failed: $e'; });
     } finally {
       if (mounted) setState(() { _retrying3D = false; });
     }

--- a/lib/screens/feedback_summary_screen.dart
+++ b/lib/screens/feedback_summary_screen.dart
@@ -1,4 +1,5 @@
 // lib/screens/feedback_summary_screen.dart
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:math' as math;
@@ -6,10 +7,10 @@ import 'dart:ui' show Size;
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:path_provider/path_provider.dart';
 
 import '../shared/services/pose_processing_controller.dart';
 import '../shared/services/summary_repository.dart';
+import '../shared/utils/session_storage.dart';
 
 class FeedbackSummaryScreen extends StatefulWidget {
   const FeedbackSummaryScreen({
@@ -58,12 +59,7 @@ class _FeedbackSummaryScreenState extends State<FeedbackSummaryScreen> {
       _out3dPath = repOut3d.toString();
     }
 
-    if (_out3dPath != null) {
-      _loading3D = true;
-      _load3D(_out3dPath!);
-    } else {
-      _loadLogTail();
-    }
+    unawaited(_refresh3DArtifacts());
   }
 
   Future<void> _load() async {
@@ -84,15 +80,40 @@ class _FeedbackSummaryScreenState extends State<FeedbackSummaryScreen> {
             summaryOut3d is String ? summaryOut3d : summaryOut3d?.toString();
       });
 
-      if (_out3dPath != null &&
-          (_mbSummary == null || _mbSummary?['path'] != _out3dPath)) {
-        _load3D(_out3dPath!);
-      } else if (_out3dPath == null && _sessionId != null && _logTail.isEmpty) {
-        _loadLogTail();
-      }
+      unawaited(_refresh3DArtifacts());
     } catch (e) {
       if (!mounted) return;
       setState(() => _error = e);
+    }
+  }
+
+  Future<void> _refresh3DArtifacts() async {
+    final outPath = _out3dPath;
+    if (outPath != null && outPath.isNotEmpty) {
+      if (_mbSummary != null && _mbSummary?['path'] == outPath) {
+        return;
+      }
+      await _load3D(outPath);
+      return;
+    }
+
+    final sid = _sessionId;
+    if (sid == null || sid.isEmpty) {
+      return;
+    }
+
+    final existingOut = await SessionStorage.findSessionFile(sid, 'out_3d.json');
+    if (existingOut != null) {
+      if (mounted) {
+        setState(() {
+          _out3dPath = existingOut.path;
+        });
+      } else {
+        _out3dPath = existingOut.path;
+      }
+      await _load3D(existingOut.path);
+    } else if (_logTail.isEmpty) {
+      await _loadLogTail();
     }
   }
 
@@ -101,9 +122,8 @@ class _FeedbackSummaryScreenState extends State<FeedbackSummaryScreen> {
     if (sid == null) return;
 
     try {
-      final docs = await getApplicationDocumentsDirectory();
-      final file = File('${docs.path}/FitPerfect/$sid/coco_2d.jsonl');
-      if (!await file.exists()) {
+      final file = await SessionStorage.findSessionFile(sid, 'coco_2d.jsonl');
+      if (file == null) {
         if (!mounted) return;
         setState(() {
           _logTail = const ['coco_2d.jsonl not found'];
@@ -209,10 +229,8 @@ class _FeedbackSummaryScreenState extends State<FeedbackSummaryScreen> {
     }
 
     try {
-      final docs = await getApplicationDocumentsDirectory();
-      final dir = Directory('${docs.path}/FitPerfect/$sid');
-      final file = File('${dir.path}/coco_2d.jsonl');
-      if (!await file.exists()) {
+      final file = await SessionStorage.findSessionFile(sid, 'coco_2d.jsonl');
+      if (file == null) {
         throw 'coco_2d.jsonl missing for session $sid';
       }
 

--- a/lib/shared/utils/session_storage.dart
+++ b/lib/shared/utils/session_storage.dart
@@ -1,0 +1,54 @@
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+
+/// Utility helpers for locating FitPerfect session artifacts on device storage.
+class SessionStorage {
+  const SessionStorage._();
+
+  /// Returns the existing session directory if it was previously written either
+  /// to the application's documents directory or the temporary directory.
+  static Future<Directory?> findExistingSessionDir(String sessionId) async {
+    final docs = await getApplicationDocumentsDirectory();
+    final docsDir = Directory('${docs.path}/FitPerfect/$sessionId');
+    if (await docsDir.exists()) {
+      return docsDir;
+    }
+
+    final temp = await getTemporaryDirectory();
+    final tempDir = Directory('${temp.path}/FitPerfect/$sessionId');
+    if (await tempDir.exists()) {
+      return tempDir;
+    }
+    return null;
+  }
+
+  /// Finds an existing file for [sessionId] named [fileName] either under the
+  /// documents directory or the temporary directory.
+  static Future<File?> findSessionFile(
+    String sessionId,
+    String fileName,
+  ) async {
+    final existingDir = await findExistingSessionDir(sessionId);
+    if (existingDir != null) {
+      final candidate = File('${existingDir.path}/$fileName');
+      if (await candidate.exists()) {
+        return candidate;
+      }
+    }
+
+    final docs = await getApplicationDocumentsDirectory();
+    final docsFile = File('${docs.path}/FitPerfect/$sessionId/$fileName');
+    if (await docsFile.exists()) {
+      return docsFile;
+    }
+
+    final temp = await getTemporaryDirectory();
+    final tempFile = File('${temp.path}/FitPerfect/$sessionId/$fileName');
+    if (await tempFile.exists()) {
+      return tempFile;
+    }
+
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add a SessionStorage helper to resolve FitPerfect session files in documents or temporary storage
- update the feedback screen to derive session metadata, auto-load out_3d.json, and fall back to the helper when reading coco_2d.jsonl
- apply the same session file resolution logic to the feedback summary screen for log tails and MotionBERT retries

## Testing
- flutter format lib/screens/feedback_screen.dart lib/screens/feedback_summary_screen.dart lib/shared/utils/session_storage.dart *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68e2c48fd514832f827ee069a0b2de4c