### PR TITLE
Refactor session storage layout and pipeline outputs

### DIFF
--- a/lib/screens/exercise_preview_screen.dart
+++ b/lib/screens/exercise_preview_screen.dart
@@ -281,7 +281,16 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
           if (!_engineStarted) {
             _sessionId = generateSessionId();
             try {
-              await _engine.start(controller: _cam, sessionId: _sessionId!);
+              final preview = _cam.value.previewSize;
+              final frameSize = preview == null
+                  ? null
+                  : Size(preview.height, preview.width);
+              await _engine.start(
+                controller: _cam,
+                sessionId: _sessionId!,
+                exerciseId: widget.exerciseId,
+                frameSize: frameSize,
+              );
               _engineStarted = true;
             } catch (e) {
               if (kDebugMode) {
@@ -310,7 +319,7 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
     if (_runningEst) return;
     _runningEst = true;
     try {
-      final pts = await _engine.estimate2D(img); // Offsets in raw camera space
+      final pts = await _engine.processFrame(img); // Offsets in raw camera space
 
       // Log for export (if we have points)
       if (pts != null) {
@@ -1041,6 +1050,11 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
       fit: StackFit.expand,
       children: [
         CameraPreview(_cam),
+        Positioned(
+          top: topPadding + 12,
+          left: 16,
+          child: _ProcessingModeChip(mode: _engine.processingMode),
+        ),
         if (showLiveSkeleton)
           AnimatedBuilder(
             animation: _skeletonAnimation,
@@ -1673,5 +1687,42 @@ class _ReferenceSkeletonOutlinePainter extends CustomPainter {
         oldDelegate.isGreen != isGreen ||
         oldDelegate.boxFit != boxFit ||
         oldDelegate.alignment != alignment;
+  }
+}
+
+class _ProcessingModeChip extends StatelessWidget {
+  const _ProcessingModeChip({required this.mode});
+
+  final ProcessingMode mode;
+
+  @override
+  Widget build(BuildContext context) {
+    final bool live = mode == ProcessingMode.liveInMemory;
+    final Color accent = live ? Colors.greenAccent : Colors.orangeAccent;
+    final IconData icon = live ? Icons.flash_on : Icons.videocam;
+    final String label = live ? 'Live 2D' : 'Recording for offline 2D';
+
+    return Material(
+      color: Colors.black.withOpacity(0.55),
+      borderRadius: BorderRadius.circular(24),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 16, color: accent),
+            const SizedBox(width: 6),
+            Text(
+              label,
+              style: TextStyle(
+                color: accent,
+                fontWeight: FontWeight.w600,
+                fontSize: 13,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lib/screens/feedback_screen.dart
+++ b/lib/screens/feedback_screen.dart
@@ -26,6 +26,9 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:path/path.dart' as p;
+import 'package:share_plus/share_plus.dart';
+
+import '../shared/services/storage_layout.dart';
 
 class FeedbackScreen extends StatefulWidget {
   const FeedbackScreen({
@@ -111,6 +114,49 @@ class _FeedbackScreenState extends State<FeedbackScreen> {
     }
   }
 
+  Future<void> _shareSessionFiles() async {
+    final sessionId = widget.sessionId;
+    if (sessionId == null) {
+      setState(() {
+        _error = 'Session ID missing – nothing to share.';
+      });
+      return;
+    }
+
+    try {
+      final files = <XFile>[];
+      final out2d = await StorageLayout.out2dFile(sessionId);
+      if (await out2d.exists()) {
+        files.add(XFile(out2d.path));
+      }
+      final out3d = await StorageLayout.out3dFile(sessionId);
+      if (await out3d.exists()) {
+        files.add(XFile(out3d.path));
+      }
+      final meta = await StorageLayout.metaFile(sessionId);
+      if (await meta.exists()) {
+        files.add(XFile(meta.path));
+      }
+      if (files.isEmpty) {
+        setState(() {
+          _error = 'No session files found to share.';
+        });
+        return;
+      }
+      await Share.shareXFiles(
+        files,
+        subject: 'FitPerfect session $sessionId',
+        text: 'Session files for $sessionId',
+      );
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _error = 'Share failed: $e';
+        });
+      }
+    }
+  }
+
   Map<String, dynamic> _summarize3d(Map<String, dynamic> root) {
     // Heuristic summary from common keys:
     int frames = 0;
@@ -173,6 +219,13 @@ class _FeedbackScreenState extends State<FeedbackScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Feedback'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.ios_share),
+            tooltip: 'Share session files',
+            onPressed: widget.sessionId == null ? null : _shareSessionFiles,
+          ),
+        ],
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
@@ -265,6 +318,8 @@ class _FeedbackScreenState extends State<FeedbackScreen> {
             ),
           ],
         ),
+        const SizedBox(height: 16),
+        _buildFileInfoCard(),
       ],
     );
   }
@@ -304,6 +359,66 @@ class _FeedbackScreenState extends State<FeedbackScreen> {
       clipBehavior: Clip.antiAlias,
       child: Column(children: items),
     );
+  }
+
+  Widget _buildFileInfoCard() {
+    final sessionId = widget.sessionId;
+    if (sessionId == null) {
+      return const SizedBox.shrink();
+    }
+    return FutureBuilder<List<_SessionFileInfo>>(
+      future: _collectFileInfo(sessionId),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const SizedBox.shrink();
+        }
+        final files = snapshot.data ?? const <_SessionFileInfo>[];
+        if (files.isEmpty) {
+          return const SizedBox.shrink();
+        }
+        return Card(
+          clipBehavior: Clip.antiAlias,
+          child: Column(
+            children: files
+                .map((info) => ListTile(
+                      leading: const Icon(Icons.article_outlined),
+                      title: Text(info.name),
+                      subtitle: Text(p.basename(info.path)),
+                      trailing: Text(
+                        '${(info.size / 1024).toStringAsFixed(1)} KB\n${info.modified.toLocal().toIso8601String()}',
+                        textAlign: TextAlign.end,
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                    ))
+                .toList(),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<List<_SessionFileInfo>> _collectFileInfo(String sessionId) async {
+    final targets = <String, Future<File>>{
+      'out_2d.jsonl': StorageLayout.out2dFile(sessionId),
+      'out_2d_index.json': StorageLayout.out2dIndexFile(sessionId),
+      'out_3d.json': StorageLayout.out3dFile(sessionId),
+      'out_3d_index.json': StorageLayout.out3dIndexFile(sessionId),
+      'meta.json': StorageLayout.metaFile(sessionId),
+    };
+    final result = <_SessionFileInfo>[];
+    for (final entry in targets.entries) {
+      final file = await entry.value;
+      if (await file.exists()) {
+        final stat = await file.stat();
+        result.add(_SessionFileInfo(
+          name: entry.key,
+          path: file.path,
+          size: stat.size,
+          modified: stat.modified,
+        ));
+      }
+    }
+    return result;
   }
 
   Widget _errorCard(String error) {
@@ -348,4 +463,18 @@ class _FeedbackScreenState extends State<FeedbackScreen> {
       ),
     );
   }
+}
+
+class _SessionFileInfo {
+  _SessionFileInfo({
+    required this.name,
+    required this.path,
+    required this.size,
+    required this.modified,
+  });
+
+  final String name;
+  final String path;
+  final int size;
+  final DateTime modified;
 }

--- a/lib/screens/feedback_summary_screen.dart
+++ b/lib/screens/feedback_summary_screen.dart
@@ -29,6 +29,9 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:path/path.dart' as p;
+import 'package:share_plus/share_plus.dart';
+
+import '../shared/services/storage_layout.dart';
 
 class FeedbackSummaryScreen extends StatefulWidget {
   const FeedbackSummaryScreen({
@@ -103,6 +106,49 @@ class _FeedbackSummaryScreenState extends State<FeedbackSummaryScreen> {
       if (mounted) {
         setState(() {
           _loading = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _shareSessionFiles() async {
+    final sessionId = widget.sessionId;
+    if (sessionId == null) {
+      setState(() {
+        _error = 'Session ID missing – nothing to share.';
+      });
+      return;
+    }
+
+    try {
+      final files = <XFile>[];
+      final out2d = await StorageLayout.out2dFile(sessionId);
+      if (await out2d.exists()) {
+        files.add(XFile(out2d.path));
+      }
+      final out3d = await StorageLayout.out3dFile(sessionId);
+      if (await out3d.exists()) {
+        files.add(XFile(out3d.path));
+      }
+      final meta = await StorageLayout.metaFile(sessionId);
+      if (await meta.exists()) {
+        files.add(XFile(meta.path));
+      }
+      if (files.isEmpty) {
+        setState(() {
+          _error = 'No session files found to share.';
+        });
+        return;
+      }
+      await Share.shareXFiles(
+        files,
+        subject: 'FitPerfect session $sessionId',
+        text: 'Session files for $sessionId',
+      );
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _error = 'Share failed: $e';
         });
       }
     }
@@ -190,6 +236,13 @@ class _FeedbackSummaryScreenState extends State<FeedbackSummaryScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Feedback Summary'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.ios_share),
+            tooltip: 'Share session files',
+            onPressed: widget.sessionId == null ? null : _shareSessionFiles,
+          ),
+        ],
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
@@ -273,6 +326,8 @@ class _FeedbackSummaryScreenState extends State<FeedbackSummaryScreen> {
             ),
           ],
         ),
+        const SizedBox(height: 16),
+        _buildFileInfoCard(),
       ],
     );
   }
@@ -329,6 +384,66 @@ class _FeedbackSummaryScreenState extends State<FeedbackSummaryScreen> {
     );
   }
 
+  Widget _buildFileInfoCard() {
+    final sessionId = widget.sessionId;
+    if (sessionId == null) {
+      return const SizedBox.shrink();
+    }
+    return FutureBuilder<List<_SessionFileInfo>>(
+      future: _collectFileInfo(sessionId),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const SizedBox.shrink();
+        }
+        final files = snapshot.data ?? const <_SessionFileInfo>[];
+        if (files.isEmpty) {
+          return const SizedBox.shrink();
+        }
+        return Card(
+          clipBehavior: Clip.antiAlias,
+          child: Column(
+            children: files
+                .map((info) => ListTile(
+                      leading: const Icon(Icons.article_outlined),
+                      title: Text(info.name),
+                      subtitle: Text(p.basename(info.path)),
+                      trailing: Text(
+                        '${(info.size / 1024).toStringAsFixed(1)} KB\n${info.modified.toLocal().toIso8601String()}',
+                        textAlign: TextAlign.end,
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                    ))
+                .toList(),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<List<_SessionFileInfo>> _collectFileInfo(String sessionId) async {
+    final targets = <String, Future<File>>{
+      'out_2d.jsonl': StorageLayout.out2dFile(sessionId),
+      'out_2d_index.json': StorageLayout.out2dIndexFile(sessionId),
+      'out_3d.json': StorageLayout.out3dFile(sessionId),
+      'out_3d_index.json': StorageLayout.out3dIndexFile(sessionId),
+      'meta.json': StorageLayout.metaFile(sessionId),
+    };
+    final result = <_SessionFileInfo>[];
+    for (final entry in targets.entries) {
+      final file = await entry.value;
+      if (await file.exists()) {
+        final stat = await file.stat();
+        result.add(_SessionFileInfo(
+          name: entry.key,
+          path: file.path,
+          size: stat.size,
+          modified: stat.modified,
+        ));
+      }
+    }
+    return result;
+  }
+
   Widget _errorCard(String error) {
     return Card(
       color: Theme.of(context).colorScheme.errorContainer,
@@ -371,4 +486,18 @@ class _FeedbackSummaryScreenState extends State<FeedbackSummaryScreen> {
       ),
     );
   }
+}
+
+class _SessionFileInfo {
+  _SessionFileInfo({
+    required this.name,
+    required this.path,
+    required this.size,
+    required this.modified,
+  });
+
+  final String name;
+  final String path;
+  final int size;
+  final DateTime modified;
 }

--- a/lib/shared/services/live_pose.dart
+++ b/lib/shared/services/live_pose.dart
@@ -3,16 +3,21 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:math' as math;
 import 'dart:typed_data';
+
 import 'package:camera/camera.dart';
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:image/image.dart' as img;
 import 'package:onnxruntime/onnxruntime.dart';
-import 'package:path_provider/path_provider.dart';
 
+import 'log.dart';
 import 'ort_session.dart';
+import 'storage_layout.dart';
 import 'tensor_utils.dart';
 import 'yuv_converter.dart';
+
+enum ProcessingMode { liveInMemory, recordThenProcess }
 
 class LivePoseEngine {
   LivePoseEngine({this.yoloEvery = 5, this.roiMargin = 1.25});
@@ -21,14 +26,24 @@ class LivePoseEngine {
   String? _sessionId;
   Directory? _sessionDir;
   IOSink? _jsonlSink;
-  String? _jsonlPath;
-  int _t = 0;
+  File? _jsonlTmpFile;
+  File? _jsonlFinalFile;
+  File? _shadow2dFile;
+  IOSink? _yoloDecodeSink;
+  ProcessingMode _processingMode = ProcessingMode.liveInMemory;
+  int _framesWritten = 0;
+  DateTime? _startedAt;
+  int _lastImgW = 0;
+  int _lastImgH = 0;
+  final _ConfidenceStats _confStats = _ConfidenceStats();
 
   final int yoloEvery;     // refresh detection every N frames
   final double roiMargin;  // crop expansion
 
   OrtSession? _yolo;
   OrtSession? _rtm;
+
+  Map<String, double>? _lbParams; // last letterbox parameters for logging/index
 
   Float32List? _yoloInputChw; // reusable buffer for YOLO input (1×3×640×640)
   Float32List? _rtmInputChw;  // reusable buffer for RTMPose input (1×3×256×192)
@@ -43,37 +58,82 @@ class LivePoseEngine {
     _yolo ??= await OrtManager.fromAsset('assets/models/yolov8n.onnx');
     _rtm  ??= await OrtManager.fromAsset('assets/models/rtmpose-m_256x192.onnx');
   }
-  /// Open the JSONL writer at Documents/FitPerfect/<sessionId>/coco_2d.jsonl
-  Future<void> start({required CameraController controller, required String sessionId, bool writeToDocuments = true}) async {
+  ProcessingMode get processingMode => _processingMode;
+
+  /// Open the JSONL writer at Documents/FitPerfect/<sessionId>/out_2d.jsonl
+  Future<void> start({
+    required CameraController controller,
+    required String sessionId,
+    String? exerciseId,
+    Size? frameSize,
+  }) async {
+    await _ensureModelsLoaded();
     _sessionId = sessionId;
-    final Directory baseDir = writeToDocuments
-        ? await getApplicationDocumentsDirectory()
-        : await getTemporaryDirectory();
-    _sessionDir = Directory('${baseDir.path}/FitPerfect/$_sessionId');
-    if (!(await _sessionDir!.exists())) {
-      await _sessionDir!.create(recursive: true);
-    }
-    _jsonlPath = '${_sessionDir!.path}/coco_2d.jsonl';
-    _jsonlSink = File(_jsonlPath!).openWrite(mode: FileMode.writeOnlyAppend);
-    _t = 0;
+    _sessionDir = await StorageLayout.sessionDir(sessionId);
+
+    _processingMode = await _decideProcessingMode();
+    _jsonlFinalFile = await StorageLayout.out2dFile(sessionId);
+    _jsonlTmpFile = File('${_jsonlFinalFile!.path}.tmp');
+    _shadow2dFile = await StorageLayout.cocoShadowFile(sessionId);
+    _jsonlSink = _jsonlTmpFile!.openWrite(mode: FileMode.write);
+    _yoloDecodeSink = (await StorageLayout.yoloDecodeLog(sessionId)).openWrite(mode: FileMode.write);
+
+    _framesWritten = 0;
+    _startedAt = DateTime.now();
+    _lastImgW = 0;
+    _lastImgH = 0;
+    _confStats.reset();
+    _lbParams = null;
+
+    await _writeMetaSeed(exerciseId: exerciseId, frameSize: frameSize);
+    Log.i('LivePose', 'start session=$sessionId mode=${_processingMode.name}');
   }
 
   /// Flush and close the JSONL file. Returns the sessionId.
   Future<String?> stop({required CameraController controller}) async {
+    final sid = _sessionId;
+    if (sid == null) return null;
     try {
       await _jsonlSink?.flush();
       await _jsonlSink?.close();
+      await _yoloDecodeSink?.flush();
+      await _yoloDecodeSink?.close();
+
+      if (_jsonlTmpFile != null && _jsonlFinalFile != null) {
+        if (await _jsonlTmpFile!.exists()) {
+          await _jsonlTmpFile!.rename(_jsonlFinalFile!.path);
+        }
+        if (_shadow2dFile != null) {
+          try {
+            await _jsonlFinalFile!.copy(_shadow2dFile!.path);
+          } catch (e) {
+            Log.w('LivePose', 'shadow copy failed: $e');
+          }
+        }
+      }
+
+      await _write2dIndex(sid);
+      await _updateMetaOnStop(sid);
+
+      final size = await _jsonlFinalFile?.exists() == true
+          ? await _jsonlFinalFile!.length()
+          : 0;
+      Log.i('LivePose', 'CLOSE wrote $_framesWritten frames → '
+          '${_jsonlFinalFile?.path} (size=$size bytes)');
     } finally {
-      final sid = _sessionId;
       _jsonlSink = null;
+      _yoloDecodeSink = null;
+      _jsonlTmpFile = null;
+      _jsonlFinalFile = null;
+      _shadow2dFile = null;
       _sessionId = null;
-      return sid;
     }
+    return sid;
   }
 
 
   /// Main entry: returns 17 keypoints in **raw camera space** (width×height).
-  Future<List<Offset>?> estimate2D(CameraImage cam) async {
+  Future<List<Offset>?> processFrame(CameraImage cam) async {
     await _ensureModelsLoaded();
     // 1) YUV → RGB
     final rgb = yuv420ToImage(cam); // width=cam.width, height=cam.height
@@ -526,6 +586,90 @@ class LivePoseEngine {
     return _Det(x1, y1, x2, y2, d.score);
   }
 
+  Future<ProcessingMode> _decideProcessingMode() async {
+    try {
+      final rssMb = ProcessInfo.currentRss / (1024 * 1024);
+      Log.i('LivePose', 'memory probe rss=${rssMb.toStringAsFixed(1)}MB');
+    } catch (e) {
+      Log.w('LivePose', 'memory probe failed: $e');
+    }
+    // Until a full RAM probe is wired, prefer live mode (current behaviour).
+    return ProcessingMode.liveInMemory;
+  }
+
+  Future<void> _writeMetaSeed({String? exerciseId, Size? frameSize}) async {
+    final sid = _sessionId;
+    if (sid == null) return;
+    final file = await StorageLayout.metaFile(sid);
+    Map<String, dynamic> meta = {};
+    if (await file.exists()) {
+      try {
+        meta = jsonDecode(await file.readAsString()) as Map<String, dynamic>;
+      } catch (_) {}
+    }
+
+    meta['sessionId'] = sid;
+    meta['exerciseId'] = exerciseId ?? meta['exerciseId'];
+    meta['startedAt'] = (_startedAt ?? DateTime.now())
+        .toUtc()
+        .toIso8601String();
+    meta['processingMode'] = _processingMode.name;
+    meta['models'] = {
+      'yolo': 'yolov8n.onnx',
+      'rtm': 'rtmpose-m_256x192.onnx',
+    };
+    if (frameSize != null) {
+      meta['frameSize'] = {
+        'width': frameSize.width,
+        'height': frameSize.height,
+      };
+    }
+
+    await file.writeAsString(const JsonEncoder.withIndent('  ').convert(meta));
+  }
+
+  Future<void> _write2dIndex(String sessionId) async {
+    final file = await StorageLayout.out2dIndexFile(sessionId);
+    final elapsed = _startedAt != null
+        ? DateTime.now().difference(_startedAt!).inMilliseconds / 1000.0
+        : 0.0;
+    final fps = elapsed > 0 ? _framesWritten / elapsed : 0.0;
+    final summary = {
+      'sessionId': sessionId,
+      'T': _framesWritten,
+      'fps': double.parse(fps.toStringAsFixed(3)),
+      'imgW': _lastImgW,
+      'imgH': _lastImgH,
+      'confidence': _confStats.toSummary(),
+      'processingMode': _processingMode.name,
+      'updatedAt': DateTime.now().toUtc().toIso8601String(),
+      if (_lbParams != null) 'letterbox': _lbParams,
+    };
+    await file.writeAsString(const JsonEncoder.withIndent('  ').convert(summary));
+  }
+
+  Future<void> _updateMetaOnStop(String sessionId) async {
+    final file = await StorageLayout.metaFile(sessionId);
+    Map<String, dynamic> meta = {};
+    if (await file.exists()) {
+      try {
+        meta = jsonDecode(await file.readAsString()) as Map<String, dynamic>;
+      } catch (_) {}
+    }
+    final elapsed = _startedAt != null
+        ? DateTime.now().difference(_startedAt!).inMilliseconds / 1000.0
+        : null;
+    meta['processingMode'] = _processingMode.name;
+    meta['frames2d'] = _framesWritten;
+    if (elapsed != null) {
+      meta['duration2dSec'] = elapsed;
+    }
+    meta['imgW'] = _lastImgW;
+    meta['imgH'] = _lastImgH;
+    meta['updatedAt'] = DateTime.now().toUtc().toIso8601String();
+    await file.writeAsString(const JsonEncoder.withIndent('  ').convert(meta));
+  }
+
   void _appendJsonl({
     required List<List<double>> kptsRaw, // [17][3] in raw px
     required _Det bboxRaw,               // raw px
@@ -534,24 +678,55 @@ class LivePoseEngine {
     required _LetterboxMeta lb,
   }) {
     if (_jsonlSink == null) return;
+    final elapsed = _startedAt != null
+        ? DateTime.now().difference(_startedAt!).inMilliseconds / 1000.0
+        : 0.0;
     final bboxNorm = [
-      bboxRaw.x1 / rawW, bboxRaw.y1 / rawH,
-      bboxRaw.x2 / rawW, bboxRaw.y2 / rawH,
-    ];
-    final line = {
-      "t": _t++,
-      "bbox": bboxNorm,
-      "score": bboxRaw.score,
-      "kpt_coco": kptsRaw,
-      "yolo_output_units": "px",
-      "yolo_output_coords": "raw",
-      "lb_scale": lb.scale,
-      "lb_padX": lb.padX,
-      "lb_padY": lb.padY,
-      "raw_w": rawW,
-      "raw_h": rawH,
+      bboxRaw.x1 / rawW,
+      bboxRaw.y1 / rawH,
+      bboxRaw.x2 / rawW,
+      bboxRaw.y2 / rawH,
+    ].map((e) => double.parse(e.toStringAsFixed(6))).toList();
+    final frame = {
+      't': double.parse(elapsed.toStringAsFixed(3)),
+      'img_w': rawW,
+      'img_h': rawH,
+      'bbox': bboxNorm,
+      'kpt': kptsRaw
+          .map((kp) => kp.map((v) => double.parse(v.toStringAsFixed(5))).toList())
+          .toList(),
+      'lb': {
+        'scale': lb.scale,
+        'pad_x': lb.padX,
+        'pad_y': lb.padY,
+      },
+      'model': {
+        'yolo': 'yolov8n.onnx',
+        'rtm': 'rtmpose-m_256x192.onnx',
+      },
+      'score': double.parse(bboxRaw.score.toStringAsFixed(3)),
     };
-    _jsonlSink!.writeln(jsonEncode(line));
+
+    _lbParams = {
+      'scale': lb.scale,
+      'pad_x': lb.padX,
+      'pad_y': lb.padY,
+    };
+
+    _jsonlSink!.writeln(jsonEncode(frame));
+    _framesWritten++;
+    _lastImgW = rawW;
+    _lastImgH = rawH;
+    _confStats.addFrame(kptsRaw);
+
+    if (_yoloDecodeSink != null && _framesWritten % 30 == 0) {
+      final tVal = frame['t'];
+      final scoreVal = frame['score'];
+      _yoloDecodeSink!.writeln(
+        '[frame=$_framesWritten] t=$tVal bbox=${bboxNorm.map((v) => v.toStringAsFixed(3)).join(',')} '
+        'score=$scoreVal',
+      );
+    }
   }
 
   Float32List _toFloat32(dynamic v) {
@@ -577,32 +752,96 @@ class LivePoseEngine {
 }
 
 // ───────── data holders ─────────
-class _Det { _Det(this.x1, this.y1, this.x2, this.y2, this.score);
-  final double x1, y1, x2, y2, score; }
+class _Det {
+  _Det(this.x1, this.y1, this.x2, this.y2, this.score);
+
+  final double x1;
+  final double y1;
+  final double x2;
+  final double y2;
+  final double score;
+}
 
 class _CropMeta {
   _CropMeta({
-    required this.roiX, required this.roiY,
-    required this.roiW, required this.roiH,
-    required this.outW, required this.outH,
+    required this.roiX,
+    required this.roiY,
+    required this.roiW,
+    required this.roiH,
+    required this.outW,
+    required this.outH,
   });
-  final double roiX, roiY, roiW, roiH;
-  final int outW, outH;
+
+  final double roiX;
+  final double roiY;
+  final double roiW;
+  final double roiH;
+  final int outW;
+  final int outH;
 }
 
-class _CropResult { _CropResult(this.image, this.meta);
-  final img.Image image; final _CropMeta meta; }
+class _CropResult {
+  _CropResult(this.image, this.meta);
+
+  final img.Image image;
+  final _CropMeta meta;
+}
 
 class _LetterboxMeta {
   _LetterboxMeta({
-    required this.srcW, required this.srcH,
-    required this.scale, required this.padX, required this.padY,
+    required this.srcW,
+    required this.srcH,
+    required this.scale,
+    required this.padX,
+    required this.padY,
   });
-  final int srcW, srcH;
-  final double scale, padX, padY;
+
+  final int srcW;
+  final int srcH;
+  final double scale;
+  final double padX;
+  final double padY;
 }
+
 class _LetterboxResult {
   _LetterboxResult({required this.square, required this.meta});
+
   final img.Image square;
   final _LetterboxMeta meta;
+}
+
+class _ConfidenceStats {
+  double _sum = 0.0;
+  double _min = double.infinity;
+  double _max = 0.0;
+  int _count = 0;
+
+  void reset() {
+    _sum = 0.0;
+    _min = double.infinity;
+    _max = 0.0;
+    _count = 0;
+  }
+
+  void addFrame(List<List<double>> joints) {
+    for (final joint in joints) {
+      if (joint.length < 3) continue;
+      final conf = joint[2];
+      _sum += conf;
+      _min = math.min(_min, conf);
+      _max = math.max(_max, conf);
+      _count++;
+    }
+  }
+
+  Map<String, double> toSummary() {
+    if (_count == 0) {
+      return {'mean': 0.0, 'min': 0.0, 'max': 0.0};
+    }
+    return {
+      'mean': _sum / _count,
+      'min': _min.isFinite ? _min : 0.0,
+      'max': _max,
+    };
+  }
 }

--- a/lib/shared/services/log.dart
+++ b/lib/shared/services/log.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/foundation.dart';
+
+typedef LogFn = void Function(String message);
+
+class Log {
+  Log._();
+
+  static DateTime _lastCoreml = DateTime.fromMillisecondsSinceEpoch(0);
+
+  static void i(String tag, String message) {
+    debugPrint('[$tag] $message');
+  }
+
+  static void w(String tag, String message) {
+    debugPrint('⚠️ [$tag] $message');
+  }
+
+  static void e(String tag, String message) {
+    debugPrint('🛑 [$tag] $message');
+  }
+
+  static void coremlOnce(String message) {
+    final now = DateTime.now();
+    if (now.difference(_lastCoreml).inSeconds >= 5) {
+      _lastCoreml = now;
+      w('CoreML', message);
+    }
+  }
+}

--- a/lib/shared/services/motionbert_runner.dart
+++ b/lib/shared/services/motionbert_runner.dart
@@ -25,10 +25,10 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' show Size;
 
-import 'package:path_provider/path_provider.dart';
-
 import 'ort_session.dart'; // OrtManager.fromAsset(...)
 import 'pipeline_debug_recorder.dart';
+import 'storage_layout.dart';
+import 'log.dart';
 
 class MotionBertRunner {
   MotionBertRunner({
@@ -49,16 +49,7 @@ class MotionBertRunner {
     bool rootRelative = true,
     bool writeNpy = false,
   }) async {
-    // Resolve session directory (Documents first, then Temp fallback).
-    final Directory docs = await getApplicationDocumentsDirectory();
-    final Directory temp = await getTemporaryDirectory();
-    final dirDocs = Directory('${docs.path}/FitPerfect/$sessionId');
-    final dirTemp = Directory('${temp.path}/FitPerfect/$sessionId');
-    final Directory sessionDir =
-        await dirDocs.exists() ? dirDocs : (await dirTemp.exists() ? dirTemp : dirDocs);
-    if (!(await sessionDir.exists())) {
-      await sessionDir.create(recursive: true);
-    }
+    final Directory sessionDir = await StorageLayout.sessionDir(sessionId);
 
     final PipelineDebugRecorder? dbg = debug
         ? PipelineDebugRecorder(
@@ -74,27 +65,24 @@ class MotionBertRunner {
       'model': modelAssetPath,
     });
 
-    
-    // Robust 2D lookup: try primary then legacy path
-    final File primary2D = File('${sessionDir.path}/coco_2d.jsonl');
-    final File legacy2D  = File('${docs.path}/FitPerfect/poses/$sessionId/2d/frames.jsonl');
+    final File primary2D = await StorageLayout.out2dFile(sessionId);
+    final File shadow2D = await StorageLayout.cocoShadowFile(sessionId);
+    final File legacy2D = await StorageLayout.legacyFramesJsonl(sessionId);
+
     dbg?.log('MB_2D_LOOKUP', {
       'primary': primary2D.path,
-      'legacy' : legacy2D.path,
+      'shadow': shadow2D.path,
+      'legacy': legacy2D.path,
     });
-    final File file2D = await primary2D.exists()
-        ? primary2D
-        : (await legacy2D.exists() ? legacy2D : primary2D);
-    if (!await file2D.exists()) {
-      // Log both attempted paths before throwing
-      final msg = 'Missing 2D keypoints: tried primary=${primary2D.path} and legacy=${legacy2D.path}';
-      dbg?.log('MB_2D_LOOKUP_FAIL', {'message': msg});
-      throw StateError(msg);
-    }
 
-    if (!await file2D.exists()) {
-      throw StateError('Missing coco_2d.jsonl at ${file2D.path}');
-    }
+    final File file2D = await _resolve2dFile(
+      primary: primary2D,
+      shadow: shadow2D,
+      legacy: legacy2D,
+    );
+
+    dbg?.log('MB_2D_SELECTED', {'path': file2D.path});
+    Log.i('MotionBERT', 'reading 2D from ${file2D.path}');
 
     try {
       // --- 1) Read COCO-17 sequence from jsonl
@@ -104,8 +92,12 @@ class MotionBertRunner {
           .transform(const LineSplitter())) {
         if (line.trim().isEmpty) continue;
         final obj = json.decode(line) as Map<String, dynamic>;
-        final kpts = (obj['kpt_coco'] as List)
-            .map<List<double>>((e) => (e as List).map((v) => (v as num).toDouble()).toList())
+        final raw = obj['kpt'] ?? obj['kpt_coco'];
+        if (raw is! List) continue;
+        final kpts = raw
+            .map<List<double>>((e) => (e as List)
+                .map((v) => (v as num?)?.toDouble() ?? 0.0)
+                .toList())
             .toList();
         if (kpts.length == 17) {
           seqCoco.add(kpts);
@@ -144,11 +136,12 @@ class MotionBertRunner {
       final double s = (math.min(W, H) / 2.0);
       final double cx = W / 2.0;
       final double cy = H / 2.0;
+      const stride = 81;
       dbg?.log('MB_PREP', {
         'sessionId': sessionId,
         'frames': seqCoco.length,
         'window': T,
-        'stride': 81,
+        'stride': stride,
         'normalize': {
           'center': [cx, cy],
           'scale': s,
@@ -239,7 +232,7 @@ class MotionBertRunner {
         final stats = {
           'frames_2d': seqCoco.length,
           'window': T,
-          'stride': 81,
+          'stride': stride,
           'z_min': zMin,
           'z_max': zMax,
         };
@@ -273,8 +266,31 @@ class MotionBertRunner {
         ],
         "coords_3d": X3D,
       };
-      final outFile = File('${sessionDir.path}/out_3d.json');
-      await outFile.writeAsString(const JsonEncoder.withIndent('  ').convert(outJson));
+      final outFile = await StorageLayout.out3dFile(sessionId);
+      final tmp = File('${outFile.path}.tmp');
+      await tmp.writeAsString(const JsonEncoder.withIndent('  ').convert(outJson));
+      if (await outFile.exists()) {
+        await outFile.delete();
+      }
+      await tmp.rename(outFile.path);
+      await _write3dIndex(
+        sessionId: sessionId,
+        frames: T,
+        stride: stride,
+        rootRelative: rootRelative,
+        zMin: zMin,
+        zMax: zMax,
+      );
+      await _updateMetaAfter3d(
+        sessionId: sessionId,
+        frames: T,
+        stride: stride,
+        rootRelative: rootRelative,
+        zMin: zMin,
+        zMax: zMax,
+      );
+      final outSize = await outFile.length();
+      Log.i('MotionBERT', '3D analysis ready (sessionId=$sessionId, out3d=$outSize bytes)');
       dbg?.log('MB_OUT_FILE', {
         'sessionId': sessionId,
         'path': outFile.path,
@@ -283,6 +299,88 @@ class MotionBertRunner {
     } finally {
       await dbg?.close();
     }
+  }
+
+  Future<File> _resolve2dFile({
+    required File primary,
+    required File shadow,
+    required File legacy,
+  }) async {
+    const attempts = 10;
+    for (int i = 0; i < attempts; i++) {
+      if (await primary.exists()) {
+        return primary;
+      }
+      await Future.delayed(const Duration(milliseconds: 100));
+    }
+
+    if (await shadow.exists()) {
+      Log.w('MotionBERT', 'using shadow 2D file at ${shadow.path}');
+      return shadow;
+    }
+
+    if (await legacy.exists()) {
+      Log.w('MotionBERT', 'using legacy 2D file at ${legacy.path}');
+      return legacy;
+    }
+
+    final msg = 'Missing 2D keypoints: tried ${primary.path}, ${shadow.path}, ${legacy.path}';
+    Log.e('MotionBERT', msg);
+    throw StateError(msg);
+  }
+
+  Future<void> _write3dIndex({
+    required String sessionId,
+    required int frames,
+    required int stride,
+    required bool rootRelative,
+    required double zMin,
+    required double zMax,
+  }) async {
+    final file = await StorageLayout.out3dIndexFile(sessionId);
+    final tmp = File('${file.path}.tmp');
+    final summary = {
+      'T': frames,
+      'window': 243,
+      'stride': stride,
+      'pelvisCentered': rootRelative,
+      'z_min': double.parse(zMin.toStringAsFixed(4)),
+      'z_max': double.parse(zMax.toStringAsFixed(4)),
+      'updatedAt': DateTime.now().toUtc().toIso8601String(),
+    };
+    await tmp.writeAsString(const JsonEncoder.withIndent('  ').convert(summary));
+    if (await file.exists()) {
+      await file.delete();
+    }
+    await tmp.rename(file.path);
+  }
+
+  Future<void> _updateMetaAfter3d({
+    required String sessionId,
+    required int frames,
+    required int stride,
+    required bool rootRelative,
+    required double zMin,
+    required double zMax,
+  }) async {
+    final metaFile = await StorageLayout.metaFile(sessionId);
+    Map<String, dynamic> meta = {};
+    if (await metaFile.exists()) {
+      try {
+        meta = jsonDecode(await metaFile.readAsString()) as Map<String, dynamic>;
+      } catch (_) {}
+    }
+    meta['frames3d'] = frames;
+    meta['motionbert'] = {
+      'model': modelAssetPath,
+      'window': 243,
+      'stride': stride,
+      'pelvisCentered': rootRelative,
+      'z_min': double.parse(zMin.toStringAsFixed(4)),
+      'z_max': double.parse(zMax.toStringAsFixed(4)),
+      'completedAt': DateTime.now().toUtc().toIso8601String(),
+    };
+    await metaFile.writeAsString(const JsonEncoder.withIndent('  ').convert(meta));
   }
 
   // ---------- helpers ----------

--- a/lib/shared/services/ort_session.dart
+++ b/lib/shared/services/ort_session.dart
@@ -34,6 +34,12 @@ class OrtManager {
     final Uint8List bytes =
         data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes);
 
+    try {
+      OrtEnv.instance.loggingSeverityLevel = OrtLoggingLevel.warning;
+    } catch (_) {
+      // Older plugin versions may not expose logging severity setters.
+    }
+
     final options = OrtSessionOptions();
 
     // Threads + graph opts

--- a/lib/shared/services/pose_processing_controller.dart
+++ b/lib/shared/services/pose_processing_controller.dart
@@ -20,10 +20,8 @@ import 'dart:math';
 import 'dart:ui' show Size;
 
 import 'package:flutter/foundation.dart';
-import 'package:path/path.dart' as p;
-import 'package:path_provider/path_provider.dart';
-
 import 'motionbert_runner.dart';
+import 'storage_layout.dart';
 
 typedef SessionId = String;
 
@@ -160,15 +158,17 @@ class PoseProcessingController extends ChangeNotifier {
     _progressCtrl.add(ProgressEvent.indeterminate(phase: 'Preparing MotionBERT'));
 
     try {
-      // Log where we expect 2D to be (primary & legacy) for quick diagnosis.
-      final paths = await _expected2DPaths(sessionId);
+      final primary = await StorageLayout.out2dFile(sessionId);
+      final shadow = await StorageLayout.cocoShadowFile(sessionId);
+      final legacy = await StorageLayout.legacyFramesJsonl(sessionId);
       debugPrint('[PoseProcessingController] 2D lookup: '
-          'primary="${paths.primary}", legacy="${paths.legacy}"');
+          'primary="${primary.path}", shadow="${shadow.path}", legacy="${legacy.path}"');
 
-      final primaryExists = await File(paths.primary).exists();
-      final legacyExists = await File(paths.legacy).exists();
+      final primaryExists = await primary.exists();
+      final shadowExists = await shadow.exists();
+      final legacyExists = await legacy.exists();
       debugPrint('[PoseProcessingController] 2D presence: '
-          'primary=$primaryExists, legacy=$legacyExists');
+          'primary=$primaryExists, shadow=$shadowExists, legacy=$legacyExists');
 
       _progressCtrl.add(
         ProgressEvent.indeterminate(phase: 'Running MotionBERT'),
@@ -228,22 +228,6 @@ class PoseProcessingController extends ChangeNotifier {
 
   // ───────────────────────────── helpers ─────────────────────────────
 
-  /// Compute the expected 2D file paths for a given session.
-  ///  - primary: Documents/FitPerfect/<sessionId>/coco_2d.jsonl
-  ///  - legacy : Documents/FitPerfect/poses/<sessionId>/2d/frames.jsonl
-  Future<_Expected2DPaths> _expected2DPaths(SessionId sessionId) async {
-    final docs = await getApplicationDocumentsDirectory();
-    final base = p.join(docs.path, 'FitPerfect');
-    final primary = p.join(base, sessionId, 'coco_2d.jsonl');
-    final legacy = p.join(base, 'poses', sessionId, '2d', 'frames.jsonl');
-    return _Expected2DPaths(primary: primary, legacy: legacy);
-  }
-}
-
-class _Expected2DPaths {
-  const _Expected2DPaths({required this.primary, required this.legacy});
-  final String primary;
-  final String legacy;
 }
 
 /// Legacy helper used by some screens to generate unique session ids.

--- a/lib/shared/services/storage_layout.dart
+++ b/lib/shared/services/storage_layout.dart
@@ -1,0 +1,100 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+/// Centralizes session file layout so every component shares the same paths.
+class StorageLayout {
+  StorageLayout._();
+
+  static Future<Directory> _baseDir() async {
+    final docs = await getApplicationDocumentsDirectory();
+    final dir = Directory(p.join(docs.path, 'FitPerfect'));
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    return dir;
+  }
+
+  static Future<Directory> sessionDir(String sessionId) async {
+    final base = await _baseDir();
+    final dir = Directory(p.join(base.path, sessionId));
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    return dir;
+  }
+
+  static Future<Directory> logsDir(String sessionId) async {
+    final dir = Directory(p.join((await sessionDir(sessionId)).path, 'logs'));
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    return dir;
+  }
+
+  static Future<Directory> cfgDir(String sessionId) async {
+    final dir = Directory(p.join((await sessionDir(sessionId)).path, 'cfg'));
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    return dir;
+  }
+
+  static Future<File> out2dFile(String sessionId) async {
+    final dir = await sessionDir(sessionId);
+    return File(p.join(dir.path, 'out_2d.jsonl'));
+  }
+
+  static Future<File> cocoShadowFile(String sessionId) async {
+    final dir = await sessionDir(sessionId);
+    return File(p.join(dir.path, 'coco_2d.jsonl'));
+  }
+
+  static Future<File> out2dIndexFile(String sessionId) async {
+    final dir = await sessionDir(sessionId);
+    return File(p.join(dir.path, 'out_2d_index.json'));
+  }
+
+  static Future<File> out3dFile(String sessionId) async {
+    final dir = await sessionDir(sessionId);
+    return File(p.join(dir.path, 'out_3d.json'));
+  }
+
+  static Future<File> out3dIndexFile(String sessionId) async {
+    final dir = await sessionDir(sessionId);
+    return File(p.join(dir.path, 'out_3d_index.json'));
+  }
+
+  static Future<File> metaFile(String sessionId) async {
+    final dir = await sessionDir(sessionId);
+    return File(p.join(dir.path, 'meta.json'));
+  }
+
+  static Future<File> yoloDecodeLog(String sessionId) async {
+    final dir = await logsDir(sessionId);
+    return File(p.join(dir.path, 'yolo_decode.txt'));
+  }
+
+  static Future<File> timingsLog(String sessionId) async {
+    final dir = await logsDir(sessionId);
+    return File(p.join(dir.path, 'timings.json'));
+  }
+
+  static Future<File> pipelineLog(String sessionId) async {
+    final dir = await logsDir(sessionId);
+    return File(p.join(dir.path, 'pipeline.txt'));
+  }
+
+  static Future<File> legacyFramesJsonl(String sessionId) async {
+    final base = await _baseDir();
+    final legacy = Directory(p.join(base.path, 'poses', sessionId, '2d'));
+    return File(p.join(legacy.path, 'frames.jsonl'));
+  }
+
+  static Future<File> localVideoFile(String exercise, DateTime timestamp) async {
+    final base = await _baseDir();
+    final name = 'local_${exercise}_${timestamp.toIso8601String().replaceAll(':', '-')}.mp4';
+    return File(p.join(base.path, name));
+  }
+}


### PR DESCRIPTION
## Summary
- add a central StorageLayout helper and logging utility for session paths
- update the live pose engine and MotionBERT runner to write the new 2D/3D artifacts and metadata
- refresh preview and feedback screens to surface processing mode, share session files, and show file info

## Testing
- not run (tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68e40e992a78832fb1d86b6cb548e4a7