### PR TITLE
Implement offline YOLO-driven pose pipeline

### DIFF
--- a/lib/screens/exercise_preview_screen.dart
+++ b/lib/screens/exercise_preview_screen.dart
@@ -1162,15 +1162,6 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
         } catch (e) {
           if (kDebugMode) debugPrint('[ExercisePreview] engine.stop error: $e');
         }
-        try {
-          final preview = _cam.value.previewSize;
-          final w = preview == null ? 0 : preview.height.toInt();
-          final h = preview == null ? 0 : preview.width.toInt();
-          await context.read<PoseProcessingController>()
-            .run3DForSession(_sessionId!, Size(w.toDouble(), h.toDouble()));
-        } catch (e) {
-          if (kDebugMode) debugPrint('[ExercisePreview] run3DForSession error: $e');
-        }
       }
 
       await Future.delayed(const Duration(milliseconds: 50)); // let native drain
@@ -1240,7 +1231,11 @@ class _ExercisePreviewScreenState extends State<ExercisePreviewScreen>
       final frameSize = Size(meta.width.toDouble(), meta.height.toDouble());
 
       // Run only the MotionBERT step (Option B).
-      final file3d = await _processingController.run3DForSession(sessionId, frameSize);
+      final file3d = await _processingController.run3DForSession(
+        sessionId,
+        frameSize,
+        videoFile: videoFile,
+      );
       final out3dPath = file3d?.path;
 
       // Minimal report payload. Your SummaryRepository can enrich/derive if needed.

--- a/lib/screens/feedback_screen.dart
+++ b/lib/screens/feedback_screen.dart
@@ -417,7 +417,7 @@ class _FeedbackScreenState extends State<FeedbackScreen> {
 
   Future<List<_SessionFileInfo>> _collectFileInfo(String sessionId) async {
     final targets = <String, Future<File>>{
-      'out_2d.jsonl': StorageLayout.out2dFile(sessionId),
+      'coco_2d.jsonl': StorageLayout.out2dFile(sessionId),
       'out_2d_index.json': StorageLayout.out2dIndexFile(sessionId),
       'out_3d.json': StorageLayout.out3dFile(sessionId),
       'out_3d_index.json': StorageLayout.out3dIndexFile(sessionId),

--- a/lib/screens/feedback_summary_screen.dart
+++ b/lib/screens/feedback_summary_screen.dart
@@ -440,7 +440,7 @@ class _FeedbackSummaryScreenState extends State<FeedbackSummaryScreen> {
 
   Future<List<_SessionFileInfo>> _collectFileInfo(String sessionId) async {
     final targets = <String, Future<File>>{
-      'out_2d.jsonl': StorageLayout.out2dFile(sessionId),
+      'coco_2d.jsonl': StorageLayout.out2dFile(sessionId),
       'out_2d_index.json': StorageLayout.out2dIndexFile(sessionId),
       'out_3d.json': StorageLayout.out3dFile(sessionId),
       'out_3d_index.json': StorageLayout.out3dIndexFile(sessionId),

--- a/lib/shared/services/live_pose.dart
+++ b/lib/shared/services/live_pose.dart
@@ -25,25 +25,21 @@ class LivePoseEngine {
   // Session/JSONL
   String? _sessionId;
   Directory? _sessionDir;
-  IOSink? _jsonlSink;
-  File? _jsonlTmpFile;
-  File? _jsonlFinalFile;
-  File? _shadow2dFile;
+  IOSink? _yoloSink;
+  File? _yoloTmpFile;
+  File? _yoloFinalFile;
   IOSink? _yoloDecodeSink;
   ProcessingMode _processingMode = ProcessingMode.liveInMemory;
   int _framesWritten = 0;
   DateTime? _startedAt;
   int _lastImgW = 0;
   int _lastImgH = 0;
-  final _ConfidenceStats _confStats = _ConfidenceStats();
 
   final int yoloEvery;     // refresh detection every N frames
   final double roiMargin;  // crop expansion
 
   OrtSession? _yolo;
   OrtSession? _rtm;
-
-  Map<String, double>? _lbParams; // last letterbox parameters for logging/index
 
   Float32List? _yoloInputChw; // reusable buffer for YOLO input (1×3×640×640)
   Float32List? _rtmInputChw;  // reusable buffer for RTMPose input (1×3×256×192)
@@ -60,7 +56,7 @@ class LivePoseEngine {
   }
   ProcessingMode get processingMode => _processingMode;
 
-  /// Open the JSONL writer at Documents/FitPerfect/<sessionId>/out_2d.jsonl
+  /// Open the JSONL writer at Documents/FitPerfect/<sessionId>/yolo_person.jsonl
   Future<void> start({
     required CameraController controller,
     required String sessionId,
@@ -72,19 +68,15 @@ class LivePoseEngine {
     _sessionDir = await StorageLayout.sessionDir(sessionId);
 
     _processingMode = await _decideProcessingMode();
-    _jsonlFinalFile = await StorageLayout.out2dFile(sessionId);
-    _jsonlTmpFile = File('${_jsonlFinalFile!.path}.tmp');
-    _shadow2dFile = await StorageLayout.cocoShadowFile(sessionId);
-    _jsonlSink = _jsonlTmpFile!.openWrite(mode: FileMode.write);
+    _yoloFinalFile = await StorageLayout.yoloDetectionsFile(sessionId);
+    _yoloTmpFile = File('${_yoloFinalFile!.path}.tmp');
+    _yoloSink = _yoloTmpFile!.openWrite(mode: FileMode.write);
     _yoloDecodeSink = (await StorageLayout.yoloDecodeLog(sessionId)).openWrite(mode: FileMode.write);
 
     _framesWritten = 0;
     _startedAt = DateTime.now();
     _lastImgW = 0;
     _lastImgH = 0;
-    _confStats.reset();
-    _lbParams = null;
-
     await _writeMetaSeed(exerciseId: exerciseId, frameSize: frameSize);
     Log.i('LivePose', 'start session=$sessionId mode=${_processingMode.name}');
   }
@@ -94,38 +86,30 @@ class LivePoseEngine {
     final sid = _sessionId;
     if (sid == null) return null;
     try {
-      await _jsonlSink?.flush();
-      await _jsonlSink?.close();
+      await _yoloSink?.flush();
+      await _yoloSink?.close();
       await _yoloDecodeSink?.flush();
       await _yoloDecodeSink?.close();
 
-      if (_jsonlTmpFile != null && _jsonlFinalFile != null) {
-        if (await _jsonlTmpFile!.exists()) {
-          await _jsonlTmpFile!.rename(_jsonlFinalFile!.path);
-        }
-        if (_shadow2dFile != null) {
-          try {
-            await _jsonlFinalFile!.copy(_shadow2dFile!.path);
-          } catch (e) {
-            Log.w('LivePose', 'shadow copy failed: $e');
-          }
+      if (_yoloTmpFile != null && _yoloFinalFile != null) {
+        if (await _yoloTmpFile!.exists()) {
+          await _yoloTmpFile!.rename(_yoloFinalFile!.path);
         }
       }
 
       await _write2dIndex(sid);
       await _updateMetaOnStop(sid);
 
-      final size = await _jsonlFinalFile?.exists() == true
-          ? await _jsonlFinalFile!.length()
+      final size = await _yoloFinalFile?.exists() == true
+          ? await _yoloFinalFile!.length()
           : 0;
       Log.i('LivePose', 'CLOSE wrote $_framesWritten frames → '
-          '${_jsonlFinalFile?.path} (size=$size bytes)');
+          '${_yoloFinalFile?.path} (size=$size bytes)');
     } finally {
-      _jsonlSink = null;
+      _yoloSink = null;
       _yoloDecodeSink = null;
-      _jsonlTmpFile = null;
-      _jsonlFinalFile = null;
-      _shadow2dFile = null;
+      _yoloTmpFile = null;
+      _yoloFinalFile = null;
       _sessionId = null;
     }
     return sid;
@@ -178,21 +162,18 @@ class LivePoseEngine {
 
     // 5) Map kpts back to raw image space and return as offsets
     final rawOffsets = <Offset>[];
-    final rawTriples = <List<double>>[];
     for (final k in kpts640) {
       final xRaw = (k[0] - lb.meta.padX) / lb.meta.scale;
       final yRaw = (k[1] - lb.meta.padY) / lb.meta.scale;
       rawOffsets.add(Offset(xRaw, yRaw));
-      rawTriples.add([xRaw, yRaw, k[2]]);
     }
 
-    if (_jsonlSink != null && _lb != null && _roi != null) {
-      _appendJsonl(
-        kptsRaw: rawTriples,
+    if (_yoloSink != null && _roi != null) {
+      _appendYolo(
         bboxRaw: _roi!,
         rawW: cam.width,
         rawH: cam.height,
-        lb: lb.meta,
+        frameIdx: _frameIdx,
       );
     }
 
@@ -640,10 +621,8 @@ class LivePoseEngine {
       'fps': double.parse(fps.toStringAsFixed(3)),
       'imgW': _lastImgW,
       'imgH': _lastImgH,
-      'confidence': _confStats.toSummary(),
       'processingMode': _processingMode.name,
       'updatedAt': DateTime.now().toUtc().toIso8601String(),
-      if (_lbParams != null) 'letterbox': _lbParams,
     };
     await file.writeAsString(const JsonEncoder.withIndent('  ').convert(summary));
   }
@@ -670,58 +649,49 @@ class LivePoseEngine {
     await file.writeAsString(const JsonEncoder.withIndent('  ').convert(meta));
   }
 
-  void _appendJsonl({
-    required List<List<double>> kptsRaw, // [17][3] in raw px
-    required _Det bboxRaw,               // raw px
+  void _appendYolo({
+    required _Det bboxRaw,
     required int rawW,
     required int rawH,
-    required _LetterboxMeta lb,
+    required int frameIdx,
   }) {
-    if (_jsonlSink == null) return;
-    final elapsed = _startedAt != null
-        ? DateTime.now().difference(_startedAt!).inMilliseconds / 1000.0
-        : 0.0;
-    final bboxNorm = [
+    final sink = _yoloSink;
+    if (sink == null) return;
+    final int nowMs = DateTime.now().millisecondsSinceEpoch;
+    final double tSec = _startedAt == null
+        ? 0.0
+        : (nowMs - _startedAt!.millisecondsSinceEpoch) / 1000.0;
+
+    final List<double> bboxNorm = [
       bboxRaw.x1 / rawW,
       bboxRaw.y1 / rawH,
       bboxRaw.x2 / rawW,
       bboxRaw.y2 / rawH,
-    ].map((e) => double.parse(e.toStringAsFixed(6))).toList();
-    final frame = {
-      't': double.parse(elapsed.toStringAsFixed(3)),
-      'img_w': rawW,
-      'img_h': rawH,
-      'bbox': bboxNorm,
-      'kpt': kptsRaw
-          .map((kp) => kp.map((v) => double.parse(v.toStringAsFixed(5))).toList())
-          .toList(),
-      'lb': {
-        'scale': lb.scale,
-        'pad_x': lb.padX,
-        'pad_y': lb.padY,
-      },
-      'model': {
-        'yolo': 'yolov8n.onnx',
-        'rtm': 'rtmpose-m_256x192.onnx',
-      },
+    ].map((v) => double.parse(v.toStringAsFixed(6))).toList();
+
+    final record = <String, dynamic>{
+      't': double.parse(tSec.toStringAsFixed(3)),
+      'ts_ms': nowMs,
+      'frame_idx': frameIdx,
+      'frame_size': [rawH, rawW],
+      'bbox_raw': [
+        double.parse(bboxRaw.x1.toStringAsFixed(3)),
+        double.parse(bboxRaw.y1.toStringAsFixed(3)),
+        double.parse(bboxRaw.x2.toStringAsFixed(3)),
+        double.parse(bboxRaw.y2.toStringAsFixed(3)),
+      ],
+      'bbox_norm': bboxNorm,
       'score': double.parse(bboxRaw.score.toStringAsFixed(3)),
     };
 
-    _lbParams = {
-      'scale': lb.scale,
-      'pad_x': lb.padX,
-      'pad_y': lb.padY,
-    };
-
-    _jsonlSink!.writeln(jsonEncode(frame));
+    sink.writeln(jsonEncode(record));
     _framesWritten++;
     _lastImgW = rawW;
     _lastImgH = rawH;
-    _confStats.addFrame(kptsRaw);
 
     if (_yoloDecodeSink != null && _framesWritten % 30 == 0) {
-      final tVal = frame['t'];
-      final scoreVal = frame['score'];
+      final tVal = record['t'];
+      final scoreVal = record['score'];
       _yoloDecodeSink!.writeln(
         '[frame=$_framesWritten] t=$tVal bbox=${bboxNorm.map((v) => v.toStringAsFixed(3)).join(',')} '
         'score=$scoreVal',
@@ -808,40 +778,4 @@ class _LetterboxResult {
 
   final img.Image square;
   final _LetterboxMeta meta;
-}
-
-class _ConfidenceStats {
-  double _sum = 0.0;
-  double _min = double.infinity;
-  double _max = 0.0;
-  int _count = 0;
-
-  void reset() {
-    _sum = 0.0;
-    _min = double.infinity;
-    _max = 0.0;
-    _count = 0;
-  }
-
-  void addFrame(List<List<double>> joints) {
-    for (final joint in joints) {
-      if (joint.length < 3) continue;
-      final conf = joint[2];
-      _sum += conf;
-      _min = math.min(_min, conf);
-      _max = math.max(_max, conf);
-      _count++;
-    }
-  }
-
-  Map<String, double> toSummary() {
-    if (_count == 0) {
-      return {'mean': 0.0, 'min': 0.0, 'max': 0.0};
-    }
-    return {
-      'mean': _sum / _count,
-      'min': _min.isFinite ? _min : 0.0,
-      'max': _max,
-    };
-  }
 }

--- a/lib/shared/services/pose_processing_controller.dart
+++ b/lib/shared/services/pose_processing_controller.dart
@@ -16,12 +16,13 @@
 
 import 'dart:async';
 import 'dart:io';
-import 'dart:math';
 import 'dart:ui' show Size;
 
 import 'package:flutter/foundation.dart';
-import 'motionbert_runner.dart';
+import 'package:path/path.dart' as p;
+
 import 'storage_layout.dart';
+import 'video_pose_pipeline.dart';
 
 typedef SessionId = String;
 
@@ -133,10 +134,10 @@ class PoseProcessingCancelled implements Exception {
 
 /// Main controller used by UI. Keeps legacy fields/methods but focuses on 3D run.
 class PoseProcessingController extends ChangeNotifier {
-  PoseProcessingController({MotionBertRunner? runner})
-      : _runner = runner ?? MotionBertRunner();
+  PoseProcessingController({VideoPosePipeline? pipeline})
+      : _pipeline = pipeline ?? VideoPosePipeline();
 
-  final MotionBertRunner _runner;
+  final VideoPosePipeline _pipeline;
 
   final _progressCtrl = StreamController<ProgressEvent>.broadcast();
   Stream<ProgressEvent> get progressStream => _progressCtrl.stream;
@@ -149,40 +150,41 @@ class PoseProcessingController extends ChangeNotifier {
   /// New API for Option B: run only the MotionBERT step after live 2D is saved.
   ///
   /// Returns the generated out_3d.json on success; null on failure.
-  Future<File?> run3DForSession(SessionId sessionId, Size frameSize) async {
+  Future<File?> run3DForSession(
+    SessionId sessionId,
+    Size frameSize, {
+    File? videoFile,
+  }) async {
     if (_busy) {
       debugPrint('[PoseProcessingController] Busy; run3DForSession ignored.');
       return null;
     }
     _busy = true;
-    _progressCtrl.add(ProgressEvent.indeterminate(phase: 'Preparing MotionBERT'));
+    _progressCtrl.add(ProgressEvent.indeterminate(phase: 'Preparing pipeline'));
 
     try {
-      final primary = await StorageLayout.out2dFile(sessionId);
-      final shadow = await StorageLayout.cocoShadowFile(sessionId);
-      final legacy = await StorageLayout.legacyFramesJsonl(sessionId);
-      debugPrint('[PoseProcessingController] 2D lookup: '
-          'primary="${primary.path}", shadow="${shadow.path}", legacy="${legacy.path}"');
+      debugPrint('[PoseProcessingController] run3DForSession session=$sessionId frameSize=$frameSize');
 
-      final primaryExists = await primary.exists();
-      final shadowExists = await shadow.exists();
-      final legacyExists = await legacy.exists();
-      debugPrint('[PoseProcessingController] 2D presence: '
-          'primary=$primaryExists, shadow=$shadowExists, legacy=$legacyExists');
+      File? inputVideo = videoFile;
+      if (inputVideo == null) {
+        final Directory dir = await StorageLayout.sessionDir(sessionId);
+        final File candidate = File(p.join(dir.path, 'video.mp4'));
+        if (!await candidate.exists()) {
+          throw StateError('Session video not found. Provide videoFile when calling run3DForSession.');
+        }
+        inputVideo = candidate;
+      }
 
-      _progressCtrl.add(
-        ProgressEvent.indeterminate(phase: 'Running MotionBERT'),
-      );
+      _progressCtrl.add(ProgressEvent.indeterminate(phase: 'Running offline 2D'));
 
-      final out = await _runner.run(
+      final summary = await _pipeline.run(
+        video: inputVideo,
         sessionId: sessionId,
-        frameSize: frameSize,
-        rootRelative: true,
       );
 
-      debugPrint('[PoseProcessingController] MotionBERT wrote: ${out.path}');
-      _progressCtrl.add(ProgressEvent.complete(phase: 'MotionBERT complete'));
-      return out;
+      _progressCtrl.add(ProgressEvent.complete(phase: 'Pipeline complete'));
+      debugPrint('[PoseProcessingController] Pipeline wrote: ${summary.out3d.path}');
+      return summary.out3d;
     } on FileSystemException catch (e, st) {
       debugPrint('[PoseProcessingController][FS-ERROR] ${e.message}\n$st');
       _progressCtrl.add(ProgressEvent.error(e.message));

--- a/lib/shared/services/storage_layout.dart
+++ b/lib/shared/services/storage_layout.dart
@@ -41,14 +41,19 @@ class StorageLayout {
     return dir;
   }
 
+  static Future<File> yoloDetectionsFile(String sessionId) async {
+    final dir = await sessionDir(sessionId);
+    return File(p.join(dir.path, 'yolo_person.jsonl'));
+  }
+
   static Future<File> out2dFile(String sessionId) async {
     final dir = await sessionDir(sessionId);
-    return File(p.join(dir.path, 'out_2d.jsonl'));
+    return File(p.join(dir.path, 'coco_2d.jsonl'));
   }
 
   static Future<File> cocoShadowFile(String sessionId) async {
     final dir = await sessionDir(sessionId);
-    return File(p.join(dir.path, 'coco_2d.jsonl'));
+    return File(p.join(dir.path, 'coco_2d_shadow.jsonl'));
   }
 
   static Future<File> out2dIndexFile(String sessionId) async {

--- a/lib/shared/services/video_pose_pipeline.dart
+++ b/lib/shared/services/video_pose_pipeline.dart
@@ -12,57 +12,12 @@ import 'pose_runtime.dart';
 import 'storage_layout.dart';
 import 'video_sampler.dart' as sampler;
 
-// Backwards-compatible aliases for legacy sampler API names that are still used
-// in parts of the application. The original implementation has moved to
-// [VideoSampler], which returns [VideoFrameBatch]. Providing the aliases here
-// ensures older call sites that expect [FrameBatch] and
-// [extractFramesAtFps(...)] continue to work without touching every import.
 typedef FrameBatch = sampler.VideoFrameBatch;
-
-Future<FrameBatch> extractFramesAtFps(
-  File src,
-  double fps, {
-  int? maxFrames,
-}) {
-  return sampler.VideoSampler.extractFramesAtFps(
-    src,
-    fps,
-    maxFrames: maxFrames,
-  );
-}
-
-class PreflightSummary {
-  PreflightSummary({
-    required this.medianMs,
-    required this.p90Ms,
-    required this.fpsChainMax,
-    required this.fpsTarget,
-    required this.dtMs,
-    required this.mode,
-  });
-
-  final double medianMs;
-  final double p90Ms;
-  final double fpsChainMax;
-  final int fpsTarget;
-  final int dtMs;
-  final String mode;
-
-  Map<String, dynamic> toJson() => {
-        'median_ms': double.parse(medianMs.toStringAsFixed(3)),
-        'p90_ms': double.parse(p90Ms.toStringAsFixed(3)),
-        'fps_chain_max': double.parse(fpsChainMax.toStringAsFixed(3)),
-        'fps_target': fpsTarget,
-        'dt_ms': dtMs,
-        'mode': mode,
-      };
-}
 
 class VideoPipelineSummary {
   VideoPipelineSummary({
     required this.sessionId,
     required this.poseResult,
-    required this.preflight,
     required this.frames2d,
     required this.windows3d,
     required this.videoFile,
@@ -73,7 +28,6 @@ class VideoPipelineSummary {
 
   final String sessionId;
   final PosePipelineResult poseResult;
-  final PreflightSummary preflight;
   final int frames2d;
   final int windows3d;
   final File videoFile;
@@ -84,21 +38,18 @@ class VideoPipelineSummary {
 
 class VideoPosePipeline {
   VideoPosePipeline({
-    this.yoloModel = 'assets/models/yolov8n.onnx',
     this.rtmModel = 'assets/models/rtmpose-m_256x192.onnx',
-    double roiMargin = 1.25,
-  }) : _roiMargin = roiMargin;
+    this.sampleInterval = const Duration(milliseconds: 125),
+    this.maxDetectionAge = const Duration(milliseconds: 500),
+  });
 
-  final String yoloModel;
   final String rtmModel;
-  final double _roiMargin;
+  final Duration sampleInterval;
+  final Duration maxDetectionAge;
 
-  OrtSession? _yolo;
   OrtSession? _rtm;
-  final PosePipeline _posePipeline = PosePipeline();
 
-  Future<void> _ensure2DModelsLoaded() async {
-    _yolo ??= await OrtManager.fromAsset(yoloModel);
+  Future<void> _ensureRtmLoaded() async {
     _rtm ??= await OrtManager.fromAsset(rtmModel);
   }
 
@@ -106,36 +57,41 @@ class VideoPosePipeline {
     required File video,
     required String sessionId,
   }) async {
-    await _ensure2DModelsLoaded();
+    await _ensureRtmLoaded();
 
     final Directory sessionDir = await StorageLayout.sessionDir(sessionId);
     final File sessionVideo = File(p.join(sessionDir.path, 'video.mp4'));
     await video.copy(sessionVideo.path);
 
-    final img.Image? referenceFrame = await _loadReferenceFrame(video);
-    if (referenceFrame == null) {
-      throw StateError('Could not decode reference frame from video');
+    final File yoloFile = await StorageLayout.yoloDetectionsFile(sessionId);
+    if (!await yoloFile.exists()) {
+      throw StateError('Missing YOLO detections at ${yoloFile.path}');
     }
 
-    final PreflightSummary preflight =
-        await _runPreflight(referenceFrame, budget: const Duration(milliseconds: 1500));
-    final int fpsTarget = math.max(1, preflight.fpsTarget);
-    final int dtMs = preflight.dtMs > 0 ? preflight.dtMs : (1000 / fpsTarget).round();
+    final List<_YoloRecord> detections = await _readYoloDetections(yoloFile);
+    if (detections.isEmpty) {
+      throw StateError('No person detections found in ${yoloFile.path}');
+    }
+
+    final int dtMs = sampleInterval.inMilliseconds;
+    final double sampleFps = dtMs > 0 ? 1000.0 / dtMs : 8.0;
 
     final sampler.VideoFrameBatch batch =
-        await sampler.VideoSampler.extractFramesAtFps(video, fpsTarget.toDouble());
+        await sampler.VideoSampler.extractFramesAtFps(sessionVideo, sampleFps);
 
     final File out2d = await StorageLayout.out2dFile(sessionId);
     final IOSink out2dSink = out2d.openWrite(mode: FileMode.write);
 
     final List<Pose2DFrame> frames = [];
-    int frameWidth = referenceFrame.width;
-    int frameHeight = referenceFrame.height;
-    int tsMs = 0;
+    int frameWidth = 0;
+    int frameHeight = 0;
+
+    int detectionCursor = 0;
+    _YoloRecord? currentDetection;
 
     for (int i = 0; i < batch.files.length; i++) {
-      final File file = batch.files[i];
-      final Uint8List bytes = await file.readAsBytes();
+      final File frameFile = batch.files[i];
+      final Uint8List bytes = await frameFile.readAsBytes();
       final img.Image? image = img.decodeImage(bytes);
       if (image == null) {
         continue;
@@ -144,102 +100,99 @@ class VideoPosePipeline {
       frameWidth = image.width;
       frameHeight = image.height;
 
-      final _ChainData chain = await _runChain(image);
-      final List<List<double>> coco = chain.coco;
-      final List<List<double>> h36m = chain.h36m;
+      final int tsMs = i * dtMs;
+      while (detectionCursor < detections.length &&
+          detections[detectionCursor].tsMs <= tsMs) {
+        currentDetection = detections[detectionCursor];
+        detectionCursor++;
+      }
 
-      final Pose2DRecord record = Pose2DRecord(
-        t: tsMs / 1000.0,
-        tsMs: tsMs,
-        frameIndex: i,
-        frameSize: [image.width, image.height],
-        bbox: chain.bbox,
-        letterbox: chain.letterbox,
-        keypoints: coco,
-      );
-      out2dSink.writeln(jsonEncode(record.toJson()));
+      final _YoloRecord? det = currentDetection;
+      if (det == null) {
+        continue;
+      }
+      if (tsMs - det.tsMs > maxDetectionAge.inMilliseconds) {
+        continue;
+      }
 
+      final _CropResult crop = _cropImage(image, det);
+      if (crop.image.width == 0 || crop.image.height == 0) {
+        continue;
+      }
+
+      final _LetterboxResult lb = _letterbox(crop.image, outW: 192, outH: 256);
+      final OrtValue input = _prepRtm(lb.image);
+      final List<OrtValue?> outs = await _run(_rtm!, {'input': input});
+      if (outs.isEmpty || outs.first == null) {
+        continue;
+      }
+      final List<List<double>> kpts = _decodeAuto(outs, lb.meta);
+      for (final OrtValue? v in outs) {
+        v?.release();
+      }
+
+      final List<List<double>> kptsRaw = _restoreToRaw(kpts, lb.meta, crop);
+      final Map<String, dynamic> record = {
+        't': double.parse((tsMs / 1000.0).toStringAsFixed(3)),
+        'ts_ms': tsMs,
+        'frame_idx': det.frameIdx,
+        'frame_size': [det.frameHeight ?? frameHeight, det.frameWidth ?? frameWidth],
+        'bbox_norm': det.bboxNorm ?? _normalize(det.bboxRaw, det.frameWidth ?? frameWidth, det.frameHeight ?? frameHeight),
+        'lb_params': lb.meta.toJson(),
+        'kpt_coco': kptsRaw
+            .map((kp) => kp.map((v) => double.parse(v.toStringAsFixed(5))).toList())
+            .toList(),
+      };
+      out2dSink.writeln(jsonEncode(record));
+
+      final List<List<double>> h36m = _cocoToH36M(kptsRaw);
       frames.add(
         Pose2DFrame(
-          frameIndex: i,
+          frameIndex: det.frameIdx,
           t: tsMs / 1000.0,
           keypoints: List.generate(17, (j) {
             final kp = h36m[j];
             return PoseKeypoint2D(id: j, x: kp[0], y: kp[1], c: kp[2]);
           }),
-          imgW: image.width,
-          imgH: image.height,
+          imgW: det.frameWidth ?? frameWidth,
+          imgH: det.frameHeight ?? frameHeight,
         ),
       );
-
-      tsMs += dtMs;
     }
 
     await out2dSink.flush();
     await out2dSink.close();
-
     await batch.cleanup();
 
-    final File cocoShadow = await StorageLayout.cocoShadowFile(sessionId);
-    try {
-      await out2d.copy(cocoShadow.path);
-    } catch (_) {}
-
-    final Pose2DSequence pose2d = Pose2DSequence(
+    final Pose2DSequence seq = Pose2DSequence(
       frames: frames,
-      fps: fpsTarget.toDouble(),
+      fps: sampleFps,
       imageWidth: frameWidth,
       imageHeight: frameHeight,
     );
 
-    final Pose3DResult pose3d =
-        await _posePipeline.estimate3D(pose2d, pelvisCentered: true);
+    final PosePipeline posePipeline = PosePipeline();
+    final Pose3DResult pose3d = await posePipeline.estimate3D(
+      seq,
+      pelvisCentered: true,
+    );
 
-    final File out3d = await StorageLayout.out3dFile(sessionId);
-    await out3d.writeAsString(jsonEncode(pose3d.sequence));
+    final PosePipelineResult result =
+        PosePipelineResult(pose2d: seq, pose3d: pose3d);
 
-    final PosePipelineResult poseResult =
-        PosePipelineResult(pose2d: pose2d, pose3d: pose3d);
-
-    final File metaFile = await StorageLayout.metaFile(sessionId);
-    final MotionBertConfig mbCfg = _posePipeline.motionBertConfig;
-
-    await metaFile.writeAsString(
-      const JsonEncoder.withIndent('  ').convert({
-        'session_id': sessionId,
-        'video': {
-          'path': sessionVideo.path,
-          'fps_target': fpsTarget,
-          'dt_ms': dtMs,
-          'size': [frameWidth, frameHeight],
-          'duration_s': frames.isEmpty ? 0.0 : double.parse(((frames.length - 1) * dtMs / 1000).toStringAsFixed(3)),
-        },
-        'preflight': preflight.toJson(),
-        'sampling': {
-          'strategy': 'timestamp',
-          'dt_ms': dtMs,
-          'fps': fpsTarget,
-        },
-        'models': {
-          'yolo': {'name': p.basename(yoloModel), 'input': [640, 640]},
-          'rtmpose': {'name': p.basename(rtmModel), 'input': [256, 192]},
-          'motionbert': {
-            'name': p.basename(mbCfg.assetPath),
-            'clip_len_max': mbCfg.window,
-            'stride': mbCfg.stride,
-          },
-        },
-        'counts': {
-          'frames_2d': frames.length,
-          'clips_3d': pose3d.windows.length,
-        },
-      }),
+    final File out3d = await _writeOut3d(sessionId, pose3d);
+    final File metaFile = await _writeMeta(
+      sessionId: sessionId,
+      sampleFps: sampleFps,
+      frameWidth: frameWidth,
+      frameHeight: frameHeight,
+      frames2d: frames.length,
+      windows3d: pose3d.windows.length,
     );
 
     return VideoPipelineSummary(
       sessionId: sessionId,
-      poseResult: poseResult,
-      preflight: preflight,
+      poseResult: result,
       frames2d: frames.length,
       windows3d: pose3d.windows.length,
       videoFile: sessionVideo,
@@ -249,104 +202,10 @@ class VideoPosePipeline {
     );
   }
 
-  Future<img.Image?> _loadReferenceFrame(File video) async {
-    final sampler.VideoFrameBatch batch =
-        await sampler.VideoSampler.extractFramesAtFps(video, 1.0, maxFrames: 1);
-    try {
-      if (batch.files.isEmpty) {
-        return null;
-      }
-      final Uint8List bytes = await batch.files.first.readAsBytes();
-      return img.decodeImage(bytes);
-    } finally {
-      await batch.cleanup();
-    }
-  }
-
-  Future<PreflightSummary> _runPreflight(
-    img.Image frame, {
-    required Duration budget,
-  }) async {
-    final List<double> samples = [];
-
-    await _runChain(frame); // warmup
-
-    final Stopwatch timer = Stopwatch()..start();
-    while (timer.elapsed < budget) {
-      final Stopwatch sw = Stopwatch()..start();
-      await _runChain(frame);
-      samples.add(sw.elapsedMicroseconds / 1000.0);
-    }
-
-    if (samples.isEmpty) {
-      samples.add(1.0);
-    }
-
-    samples.sort();
-    final double median = samples[samples.length ~/ 2];
-    final int p90Index = ((samples.length - 1) * 0.9).round();
-    final double p90 = samples[p90Index.clamp(0, samples.length - 1)];
-    final double fpsChainMax = median > 0 ? 1000.0 / median : 0.0;
-    final int fpsTarget = fpsChainMax.isFinite && fpsChainMax > 0
-        ? math.max(1, (0.8 * fpsChainMax).floor())
-        : 1;
-    final int dtMs = fpsTarget > 0 ? (1000 / fpsTarget).round() : 125;
-    final String mode = fpsTarget >= 8 ? 'live' : 'post';
-
-    return PreflightSummary(
-      medianMs: median,
-      p90Ms: p90,
-      fpsChainMax: fpsChainMax,
-      fpsTarget: fpsTarget,
-      dtMs: dtMs,
-      mode: mode,
-    );
-  }
-
-  Future<_ChainData> _runChain(img.Image image) async {
-    final _LetterboxResult lb = _letterbox(image);
-    final OrtValue yoloInput = _prepYolo(lb.image);
-    final List<OrtValue?> yoloOuts = await _run(_yolo!, {'images': yoloInput});
-
-    _Det? det;
-    if (yoloOuts.isNotEmpty && yoloOuts.first != null) {
-      det = _pickLargestPerson(yoloOuts.first!, lb.meta, image.width, image.height);
-    }
-    for (final OrtValue? v in yoloOuts) {
-      v?.release();
-    }
-
-    if (det == null) {
-      return _ChainData(
-        letterbox: lb.meta,
-        bbox: null,
-        coco: List.generate(17, (_) => [0.0, 0.0, 0.0]),
-        h36m: List.generate(17, (_) => [0.0, 0.0, 0.0]),
-      );
-    }
-
-    final _Det detLb = _rawToLb(det, lb.meta, clamp: true, margin: _roiMargin);
-    final _CropResult crop = _cropForRtm(lb.image, detLb, outH: 256, outW: 192);
-    final OrtValue rtmInput = _prepRtm(crop.image);
-    final List<OrtValue?> rtmOuts = await _run(_rtm!, {'input': rtmInput});
-
-    final List<List<double>> kpts640 = _decodeAuto(rtmOuts, crop.meta);
-    for (final OrtValue? v in rtmOuts) {
-      v?.release();
-    }
-
-    final List<List<double>> coco = _toRawCoords(kpts640, lb.meta, image.width, image.height);
-    final List<List<double>> h36m = _cocoToH36M(coco);
-
-    return _ChainData(
-      letterbox: lb.meta,
-      bbox: det,
-      coco: coco,
-      h36m: h36m,
-    );
-  }
-
-  Future<List<OrtValue?>> _run(OrtSession session, Map<String, OrtValue> inputs) async {
+  Future<List<OrtValue?>> _run(
+    OrtSession session,
+    Map<String, OrtValue> inputs,
+  ) async {
     final opts = OrtRunOptions();
     final outs = await session.runAsync(opts, inputs);
     opts.release();
@@ -356,11 +215,61 @@ class VideoPosePipeline {
     return outs ?? const [];
   }
 
-  _LetterboxResult _letterbox(img.Image src) {
-    const int outSize = 640;
-    final double r = math.min(outSize / src.width, outSize / src.height);
-    final int newW = (src.width * r).round();
-    final int newH = (src.height * r).round();
+  Future<List<_YoloRecord>> _readYoloDetections(File file) async {
+    final List<_YoloRecord> records = [];
+    await for (final line in file.openRead()
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())) {
+      if (line.trim().isEmpty) continue;
+      final dynamic obj = json.decode(line);
+      if (obj is Map<String, dynamic>) {
+        final rec = _YoloRecord.fromJson(obj);
+        if (rec != null) {
+          records.add(rec);
+        }
+      }
+    }
+    records.sort((a, b) => a.tsMs.compareTo(b.tsMs));
+    return records;
+  }
+
+  _CropResult _cropImage(img.Image image, _YoloRecord det) {
+    final double x1 = det.bboxRaw[0];
+    final double y1 = det.bboxRaw[1];
+    final double x2 = det.bboxRaw[2];
+    final double y2 = det.bboxRaw[3];
+
+    final int ix1 = x1.floor().clamp(0, image.width - 1);
+    final int iy1 = y1.floor().clamp(0, image.height - 1);
+    final int ix2 = x2.ceil().clamp(ix1 + 1, image.width);
+    final int iy2 = y2.ceil().clamp(iy1 + 1, image.height);
+
+    final img.Image crop = img.copyCrop(
+      image,
+      x: ix1,
+      y: iy1,
+      width: (ix2 - ix1).clamp(1, image.width),
+      height: (iy2 - iy1).clamp(1, image.height),
+    );
+    return _CropResult(
+      image: crop,
+      meta: _CropMeta(
+        x1: ix1.toDouble(),
+        y1: iy1.toDouble(),
+        width: crop.width,
+        height: crop.height,
+      ),
+    );
+  }
+
+  _LetterboxResult _letterbox(
+    img.Image src, {
+    required int outW,
+    required int outH,
+  }) {
+    final double r = math.min(outW / src.width, outH / src.height);
+    final int newW = (src.width * r).round().clamp(1, outW);
+    final int newH = (src.height * r).round().clamp(1, outH);
 
     final img.Image resized = img.copyResize(
       src,
@@ -369,41 +278,26 @@ class VideoPosePipeline {
       interpolation: img.Interpolation.cubic,
     );
 
-    final img.Image canvas = img.Image(width: outSize, height: outSize);
+    final img.Image canvas = img.Image(width: outW, height: outH);
     img.fill(canvas, color: img.ColorRgb8(114, 114, 114));
-    final int dw = ((outSize - newW) / 2).floor();
-    final int dh = ((outSize - newH) / 2).floor();
-    img.compositeImage(canvas, resized, dstX: dw, dstY: dh);
+
+    final double dw = (outW - newW) / 2.0;
+    final double dh = (outH - newH) / 2.0;
+
+    img.compositeImage(canvas, resized, dstX: dw.floor(), dstY: dh.floor());
 
     return _LetterboxResult(
       image: canvas,
       meta: _LetterboxMeta(
+        r: r,
+        dw: dw,
+        dh: dh,
         inW: src.width,
         inH: src.height,
-        outW: outSize,
-        outH: outSize,
-        r: r,
-        dw: dw.toDouble(),
-        dh: dh.toDouble(),
+        outW: outW,
+        outH: outH,
       ),
     );
-  }
-
-  OrtValue _prepYolo(img.Image im) {
-    final int w = im.width;
-    final int h = im.height;
-    final int plane = w * h;
-    final Float32List buf = Float32List(plane * 3);
-    for (int y = 0; y < h; y++) {
-      for (int x = 0; x < w; x++) {
-        final img.Pixel pixel = im.getPixel(x, y);
-        final int idx = y * w + x;
-        buf[idx] = pixel.rNormalized.toDouble();
-        buf[plane + idx] = pixel.gNormalized.toDouble();
-        buf[(plane * 2) + idx] = pixel.bNormalized.toDouble();
-      }
-    }
-    return OrtValueTensor.createTensorWithDataList(buf, [1, 3, h, w]);
   }
 
   OrtValue _prepRtm(img.Image patch) {
@@ -413,283 +307,126 @@ class VideoPosePipeline {
     final Float32List buf = Float32List(plane * 3);
     const List<double> mean = [0.485, 0.456, 0.406];
     const List<double> std = [0.229, 0.224, 0.225];
-    for (int y = 0; y < h; y++) {
-      for (int x = 0; x < w; x++) {
-        final img.Pixel pixel = patch.getPixel(x, y);
-        final int idx = y * w + x;
-        final double r = pixel.rNormalized.toDouble();
-        final double g = pixel.gNormalized.toDouble();
-        final double b = pixel.bNormalized.toDouble();
-        buf[idx] = (r - mean[0]) / std[0];
-        buf[plane + idx] = (g - mean[1]) / std[1];
-        buf[(plane * 2) + idx] = (b - mean[2]) / std[2];
-      }
+
+    final Uint8List rgb = patch.getBytes(order: img.ChannelOrder.rgb);
+    for (int i = 0, p = 0; p < plane; p++) {
+      final double r = rgb[i++] / 255.0;
+      final double g = rgb[i++] / 255.0;
+      final double b = rgb[i++] / 255.0;
+      buf[p] = (r - mean[0]) / std[0];
+      buf[plane + p] = (g - mean[1]) / std[1];
+      buf[(plane * 2) + p] = (b - mean[2]) / std[2];
     }
     return OrtValueTensor.createTensorWithDataList(buf, [1, 3, h, w]);
   }
 
-  _Det? _pickLargestPerson(
-    OrtValue output,
-    _LetterboxMeta lb,
-    int imgW,
-    int imgH,
+  List<List<double>> _decodeAuto(List<OrtValue?> outs, _LetterboxMeta meta) {
+    if (outs.isEmpty || outs.first == null) {
+      return List.generate(17, (_) => [0.0, 0.0, 0.0]);
+    }
+    final OrtValue out = outs.first!;
+    final List<int> shape = _shapeOf(out.value);
+    if (shape.length == 4 && shape[1] == 17 && shape.last == 2) {
+      // SimCC: [1,17,2,256]
+      return _decodeSimcc(out.value, shape, meta);
+    }
+    if (shape.length == 4 && shape[1] == 17) {
+      // Heatmap
+      return _decodeHeatmap(out.value, shape, meta);
+    }
+    return List.generate(17, (_) => [0.0, 0.0, 0.0]);
+  }
+
+  List<List<double>> _decodeHeatmap(
+    dynamic value,
+    List<int> shape,
+    _LetterboxMeta meta,
   ) {
-    final List<int> shape = _shapeOf(output.value);
-    if (shape.length != 3 || shape[0] != 1) {
-      return null;
-    }
-
-    final List<List<double>> rows = _extractYoloRows(output.value, shape);
-    if (rows.isEmpty) {
-      return null;
-    }
-
-    final List<List<double>> boxes = [];
-    final List<double> scores = [];
-    for (final row in rows) {
-      if (row.length < 84) continue;
-      final double obj = row[4];
-      final double cls = row[5];
-      final double score = _sigmoid(obj) * _sigmoid(cls);
-      if (score < 0.25) continue;
-
-      final double cx = row[0];
-      final double cy = row[1];
-      final double w = row[2];
-      final double h = row[3];
-      final bool normalized =
-          cx.abs() <= 2.0 && cy.abs() <= 2.0 && w.abs() <= 2.0 && h.abs() <= 2.0;
-      final double scale = normalized ? lb.outW.toDouble() : 1.0;
-
-      final double x1 = (cx - w / 2) * scale;
-      final double y1 = (cy - h / 2) * scale;
-      final double x2 = (cx + w / 2) * scale;
-      final double y2 = (cy + h / 2) * scale;
-
-      final double rawX1 = ((x1 - lb.dw) / lb.r).clamp(0.0, imgW.toDouble());
-      final double rawY1 = ((y1 - lb.dh) / lb.r).clamp(0.0, imgH.toDouble());
-      final double rawX2 = ((x2 - lb.dw) / lb.r).clamp(0.0, imgW.toDouble());
-      final double rawY2 = ((y2 - lb.dh) / lb.r).clamp(0.0, imgH.toDouble());
-
-      if (rawX2 <= rawX1 || rawY2 <= rawY1) continue;
-
-      boxes.add([rawX1, rawY1, rawX2, rawY2]);
-      scores.add(score);
-    }
-
-    if (boxes.isEmpty) {
-      return null;
-    }
-
-    final List<int> keep = _nms(boxes, scores, 0.45, 50);
-    if (keep.isEmpty) {
-      return null;
-    }
-
-    int best = keep.first;
-    double bestArea = _area(boxes[best]);
-    double bestScore = scores[best];
-    for (final idx in keep.skip(1)) {
-      final double area = _area(boxes[idx]);
-      final double score = scores[idx];
-      if (area > bestArea || (area == bestArea && score > bestScore)) {
-        best = idx;
-        bestArea = area;
-        bestScore = score;
-      }
-    }
-
-    final List<double> b = boxes[best];
-    return _Det(b[0], b[1], b[2], b[3], scores[best]);
-  }
-
-  _Det _rawToLb(
-    _Det det,
-    _LetterboxMeta lb, {
-    bool clamp = true,
-    double margin = 1.0,
-  }) {
-    final double cx = (det.x1 + det.x2) * 0.5;
-    final double cy = (det.y1 + det.y2) * 0.5;
-    double w = (det.x2 - det.x1) * margin;
-    double h = (det.y2 - det.y1) * margin;
-    if (w <= 1) w = 1;
-    if (h <= 1) h = 1;
-
-    double x1 = cx - w / 2;
-    double y1 = cy - h / 2;
-    double x2 = cx + w / 2;
-    double y2 = cy + h / 2;
-
-    x1 = x1 * lb.r + lb.dw;
-    y1 = y1 * lb.r + lb.dh;
-    x2 = x2 * lb.r + lb.dw;
-    y2 = y2 * lb.r + lb.dh;
-
-    if (clamp) {
-      x1 = x1.clamp(0.0, lb.outW.toDouble());
-      y1 = y1.clamp(0.0, lb.outH.toDouble());
-      x2 = x2.clamp(0.0, lb.outW.toDouble());
-      y2 = y2.clamp(0.0, lb.outH.toDouble());
-    }
-
-    return _Det(x1, y1, x2, y2, det.score);
-  }
-
-  _CropResult _cropForRtm(img.Image image, _Det det, {required int outH, required int outW}) {
-    final double x1 = det.x1.clamp(0.0, image.width.toDouble());
-    final double y1 = det.y1.clamp(0.0, image.height.toDouble());
-    final double x2 = det.x2.clamp(0.0, image.width.toDouble());
-    final double y2 = det.y2.clamp(0.0, image.height.toDouble());
-
-    final img.Image cropped = img.copyCrop(
-      image,
-      x: x1.toInt(),
-      y: y1.toInt(),
-      width: math.max(1, (x2 - x1).toInt()),
-      height: math.max(1, (y2 - y1).toInt()),
-    );
-
-    final img.Image resized = img.copyResize(
-      cropped,
-      width: outW,
-      height: outH,
-      interpolation: img.Interpolation.cubic,
-    );
-
-    final _CropMeta meta = _CropMeta(
-      roiX: x1,
-      roiY: y1,
-      roiW: (x2 - x1),
-      roiH: (y2 - y1),
-      outW: outW,
-      outH: outH,
-    );
-
-    return _CropResult(image: resized, meta: meta);
-  }
-
-  List<List<double>> _decodeAuto(List<OrtValue?> outs, _CropMeta meta) {
-    if (outs.isEmpty || outs[0] == null) {
-      return List.generate(17, (_) => [0.0, 0.0, 0.0]);
-    }
-    final List<int> shape0 = _shapeOf(outs[0]!.value);
-    if (shape0.length == 4) {
-      return _decodeHeatmap(outs[0]!, meta);
-    }
-    if (outs.length >= 2) {
-      final List<int> shape1 = _shapeOf(outs[1]!.value);
-      final bool looksSimcc =
-          shape0.length == 3 && shape1.length == 3 && shape0[0] == 1 && shape1[0] == 1;
-      if (looksSimcc) {
-        final bool firstIsX = shape0.last <= shape1.last;
-        final List<OrtValue?> ordered = firstIsX ? outs : [outs[1], outs[0]];
-        return _decodeSimCC(ordered, meta);
-      }
-    }
-    return _decodeHeatmap(outs[0]!, meta);
-  }
-
-  List<List<double>> _decodeHeatmap(OrtValue heat, _CropMeta meta) {
-    final List data = heat.value as List;
-    if (data.isEmpty) {
-      return List.generate(17, (_) => [0.0, 0.0, 0.0]);
-    }
-    final List joints = data[0] as List;
-    final int H = (joints[0] as List).length;
-    final int W = ((joints[0] as List)[0] as List).length;
-    final List<List<double>> result = List.generate(17, (_) => [0.0, 0.0, 0.0]);
-    for (int j = 0; j < math.min(17, joints.length); j++) {
-      final List plane = joints[j] as List;
-      double best = -1e9;
-      int bx = 0;
-      int by = 0;
+    final int H = shape[2];
+    final int W = shape[3];
+    final List<List<double>> points = List.generate(17, (_) => [0.0, 0.0, 0.0]);
+    for (int k = 0; k < 17; k++) {
+      double best = -double.infinity;
+      int bestX = 0;
+      int bestY = 0;
       for (int y = 0; y < H; y++) {
-        final List row = plane[y] as List;
         for (int x = 0; x < W; x++) {
-          final double v = (row[x] as num).toDouble();
-          if (v > best) {
-            best = v;
-            bx = x;
-            by = y;
+          final double score = ((value[0][k][y][x]) as num).toDouble();
+          if (score > best) {
+            best = score;
+            bestX = x;
+            bestY = y;
           }
         }
       }
-      final double px = (bx + 0.5) * (meta.outW / W);
-      final double py = (by + 0.5) * (meta.outH / H);
-      result[j][0] = meta.roiX + (px / meta.outW) * meta.roiW;
-      result[j][1] = meta.roiY + (py / meta.outH) * meta.roiH;
-      result[j][2] = 1.0;
+      final double px = bestX * (meta.outW / W) + meta.dw;
+      final double py = bestY * (meta.outH / H) + meta.dh;
+      points[k][0] = px;
+      points[k][1] = py;
+      points[k][2] = best;
     }
-    return result;
+    return points;
   }
 
-  List<List<double>> _decodeSimCC(List<OrtValue?> outs, _CropMeta meta) {
-    final List<List<List<double>>> x = _toList3D(outs[0]!.value);
-    final List<List<List<double>>> y = _toList3D(outs[1]!.value);
-    final int joints = math.min(17, x[0].length);
-    final List<List<double>> result = List.generate(17, (_) => [0.0, 0.0, 0.0]);
-    const double split = 2.0;
-    for (int j = 0; j < joints; j++) {
-      final List<double> rowX = x[0][j];
-      final List<double> rowY = y[0][j];
-      int ix = 0;
-      int iy = 0;
-      double vx = -1e9;
-      double vy = -1e9;
-      for (int i = 0; i < rowX.length; i++) {
-        if (rowX[i] > vx) {
-          vx = rowX[i];
-          ix = i;
+  List<List<double>> _decodeSimcc(
+    dynamic value,
+    List<int> shape,
+    _LetterboxMeta meta,
+  ) {
+    final int bins = shape[3];
+    final List<List<double>> points = List.generate(17, (_) => [0.0, 0.0, 0.0]);
+    for (int k = 0; k < 17; k++) {
+      final List xBins = value[0][k][0] as List;
+      final List yBins = value[0][k][1] as List;
+      int argMaxX = 0;
+      int argMaxY = 0;
+      double maxX = -double.infinity;
+      double maxY = -double.infinity;
+      for (int i = 0; i < bins; i++) {
+        final double vx = (xBins[i] as num).toDouble();
+        if (vx > maxX) {
+          maxX = vx;
+          argMaxX = i;
+        }
+        final double vy = (yBins[i] as num).toDouble();
+        if (vy > maxY) {
+          maxY = vy;
+          argMaxY = i;
         }
       }
-      for (int i = 0; i < rowY.length; i++) {
-        if (rowY[i] > vy) {
-          vy = rowY[i];
-          iy = i;
-        }
-      }
-      final double px = ix / split;
-      final double py = iy / split;
-      result[j][0] = meta.roiX + (px / meta.outW) * meta.roiW;
-      result[j][1] = meta.roiY + (py / meta.outH) * meta.roiH;
-      result[j][2] = math.min(1.0, math.max(0.0, (vx + vy) * 0.5));
+      final double px = argMaxX * (meta.outW / bins) + meta.dw;
+      final double py = argMaxY * (meta.outH / bins) + meta.dh;
+      points[k][0] = px;
+      points[k][1] = py;
+      points[k][2] = math.min(maxX, maxY);
     }
-    return result;
+    return points;
   }
 
-  List<List<List<double>>> _toList3D(dynamic v) =>
-      (v as List)
-          .map<List<List<double>>>((a) =>
-              (a as List)
-                  .map<List<double>>((b) =>
-                      (b as List).map<double>((c) => (c as num).toDouble()).toList())
-                  .toList())
-          .toList();
-
-  List<int> _shapeOf(dynamic v) {
+  List<int> _shapeOf(dynamic value) {
     final List<int> dims = [];
-    dynamic cur = v;
-    while (cur is List) {
+    dynamic cur = value;
+    while (cur is List && cur.isNotEmpty) {
       dims.add(cur.length);
-      cur = cur.isNotEmpty ? cur[0] : null;
+      cur = cur.first;
     }
     return dims;
   }
 
-  List<List<double>> _toRawCoords(
+  List<List<double>> _restoreToRaw(
     List<List<double>> kpts,
     _LetterboxMeta lb,
-    int imgW,
-    int imgH,
+    _CropResult crop,
   ) {
     final List<List<double>> result =
         List.generate(kpts.length, (_) => [0.0, 0.0, 0.0]);
     for (int i = 0; i < kpts.length; i++) {
-      final double x = ((kpts[i][0] - lb.dw) / lb.r).clamp(0.0, imgW.toDouble());
-      final double y = ((kpts[i][1] - lb.dh) / lb.r).clamp(0.0, imgH.toDouble());
-      result[i][0] = x;
-      result[i][1] = y;
+      final double x = (kpts[i][0] - lb.dw) / lb.r;
+      final double y = (kpts[i][1] - lb.dh) / lb.r;
+      final double rawX = (x + crop.meta.x1).clamp(0.0, double.infinity);
+      final double rawY = (y + crop.meta.y1).clamp(0.0, double.infinity);
+      result[i][0] = rawX;
+      result[i][1] = rawY;
       result[i][2] = kpts[i][2];
     }
     return result;
@@ -700,20 +437,24 @@ class VideoPosePipeline {
     double py(int i) => coco[i][1];
     double pc(int i) => coco[i][2];
 
-    final List<double> lhip = [px(11), py(11)];
-    final List<double> rhip = [px(12), py(12)];
-    final List<double> pelvis = [(lhip[0] + rhip[0]) / 2.0, (lhip[1] + rhip[1]) / 2.0];
-    final List<double> lsho = [px(5), py(5)];
-    final List<double> rsho = [px(6), py(6)];
-    final List<double> neck = [(lsho[0] + rsho[0]) / 2.0, (lsho[1] + rsho[1]) / 2.0];
-    final List<double> spine1 = [(pelvis[0] + neck[0]) / 2.0, (pelvis[1] + neck[1]) / 2.0];
-    final List<double> nose = [px(0), py(0)];
-    final List<double> leye = [px(1), py(1)];
-    final List<double> reye = [px(2), py(2)];
-    final bool hasEyes = pc(1) > 0 && pc(2) > 0;
-    final List<double> head = hasEyes
-        ? [(leye[0] + reye[0]) / 2.0, (leye[1] + reye[1]) / 2.0]
-        : [nose[0], nose[1]];
+    final pelvisX = (px(11) + px(12)) / 2.0;
+    final pelvisY = (py(11) + py(12)) / 2.0;
+    final neckX = (px(5) + px(6)) / 2.0;
+    final neckY = (py(5) + py(6)) / 2.0;
+    final spineX = (pelvisX + neckX) / 2.0;
+    final spineY = (pelvisY + neckY) / 2.0;
+
+    final headPoints = [1, 2, 3, 4]
+        .where((i) => pc(i) > 0)
+        .map((i) => [px(i), py(i)])
+        .toList();
+    final headX = headPoints.isEmpty
+        ? px(0)
+        : headPoints.map((p) => p[0]).reduce((a, b) => a + b) / headPoints.length;
+    final headY = headPoints.isEmpty
+        ? py(0)
+        : headPoints.map((p) => p[1]).reduce((a, b) => a + b) / headPoints.length;
+
     final List<List<double>> h36m = List.generate(17, (_) => [0.0, 0.0, 0.0]);
 
     void setJoint(int idx, double x, double y, double c) {
@@ -722,22 +463,17 @@ class VideoPosePipeline {
       h36m[idx][2] = c;
     }
 
-    final double cPelvis = (pc(11) + pc(12)) / 2.0;
-    final double cNeck = (pc(5) + pc(6)) / 2.0;
-    final double cSpine1 = (cPelvis + cNeck) / 2.0;
-    final double cHead = hasEyes ? (pc(1) + pc(2)) / 2.0 : pc(0);
-
-    setJoint(0, pelvis[0], pelvis[1], cPelvis);
+    setJoint(0, pelvisX, pelvisY, (pc(11) + pc(12)) / 2.0);
     setJoint(1, px(12), py(12), pc(12));
     setJoint(2, px(14), py(14), pc(14));
     setJoint(3, px(16), py(16), pc(16));
     setJoint(4, px(11), py(11), pc(11));
     setJoint(5, px(13), py(13), pc(13));
     setJoint(6, px(15), py(15), pc(15));
-    setJoint(7, spine1[0], spine1[1], cSpine1);
-    setJoint(8, neck[0], neck[1], cNeck);
-    setJoint(9, head[0], head[1], cHead);
-    setJoint(10, nose[0], nose[1], pc(0));
+    setJoint(7, spineX, spineY, (pc(11) + pc(12) + pc(5) + pc(6)) / 4.0);
+    setJoint(8, neckX, neckY, (pc(5) + pc(6)) / 2.0);
+    setJoint(9, headX, headY, pc(0));
+    setJoint(10, px(0), py(0), pc(0));
     setJoint(11, px(5), py(5), pc(5));
     setJoint(12, px(7), py(7), pc(7));
     setJoint(13, px(9), py(9), pc(9));
@@ -748,196 +484,188 @@ class VideoPosePipeline {
     return h36m;
   }
 
-  List<List<double>> _extractYoloRows(dynamic value, List<int> shape) {
-    if (shape[1] == 84) {
-      final List channels = (value as List)[0] as List;
-      final int count = shape[2];
-      return List.generate(count, (i) {
-        final List<double> row = List.filled(84, 0.0);
-        for (int c = 0; c < 84; c++) {
-          row[c] = ((channels[c] as List)[i] as num).toDouble();
-        }
-        return row;
-      });
-    }
-    if (shape[2] == 84) {
-      return ((value as List)[0] as List)
-          .map<List<double>>((row) =>
-              (row as List).map<double>((e) => (e as num).toDouble()).toList())
-          .toList();
-    }
-    return const [];
+  List<double> _normalize(List<double> bbox, int width, int height) {
+    return [
+      bbox[0] / width,
+      bbox[1] / height,
+      bbox[2] / width,
+      bbox[3] / height,
+    ]
+        .map((v) => double.parse(v.toStringAsFixed(6)))
+        .toList();
   }
 
-  double _sigmoid(double x) => 1 / (1 + math.exp(-x));
-
-  List<int> _nms(
-    List<List<double>> boxes,
-    List<double> scores,
-    double iouThr,
-    int maxDet,
-  ) {
-    final List<int> order = List<int>.generate(scores.length, (i) => i)
-      ..sort((a, b) => scores[b].compareTo(scores[a]));
-    final List<int> keep = [];
-    while (order.isNotEmpty && keep.length < maxDet) {
-      final int i = order.removeAt(0);
-      keep.add(i);
-      order.removeWhere((j) => _iou(boxes[i], boxes[j]) > iouThr);
+  Future<File> _writeOut3d(String sessionId, Pose3DResult pose3d) async {
+    final File out3d = await StorageLayout.out3dFile(sessionId);
+    final tmp = File('${out3d.path}.tmp');
+    final Map<String, dynamic> payload = {
+      'T': pose3d.sequence.length,
+      'h36m_order': const [
+        'Pelvis',
+        'RHip',
+        'RKnee',
+        'RAnkle',
+        'LHip',
+        'LKnee',
+        'LAnkle',
+        'Spine1',
+        'Neck',
+        'Head',
+        'Site',
+        'LShoulder',
+        'LElbow',
+        'LWrist',
+        'RShoulder',
+        'RElbow',
+        'RWrist'
+      ],
+      'coords_3d': pose3d.sequence,
+    };
+    await tmp.writeAsString(const JsonEncoder.withIndent('  ').convert(payload));
+    if (await out3d.exists()) {
+      await out3d.delete();
     }
-    return keep;
+    await tmp.rename(out3d.path);
+    return out3d;
   }
 
-  double _iou(List<double> a, List<double> b) {
-    final double x1 = math.max(a[0], b[0]);
-    final double y1 = math.max(a[1], b[1]);
-    final double x2 = math.min(a[2], b[2]);
-    final double y2 = math.min(a[3], b[3]);
-    final double interW = math.max(0.0, x2 - x1);
-    final double interH = math.max(0.0, y2 - y1);
-    final double inter = interW * interH;
-    if (inter <= 0) return 0.0;
-    final double areaA = _area(a);
-    final double areaB = _area(b);
-    final double union = areaA + areaB - inter;
-    if (union <= 0) return 0.0;
-    return inter / union;
+  Future<File> _writeMeta({
+    required String sessionId,
+    required double sampleFps,
+    required int frameWidth,
+    required int frameHeight,
+    required int frames2d,
+    required int windows3d,
+  }) async {
+    final File meta = await StorageLayout.metaFile(sessionId);
+    final double durationSec = frames2d <= 1
+        ? (frames2d == 1 ? sampleInterval.inMilliseconds / 1000.0 : 0.0)
+        : ((frames2d - 1) * sampleInterval.inMilliseconds) / 1000.0;
+    final Map<String, dynamic> payload = {
+      'session_id': sessionId,
+      'video': {
+        'fps': double.parse(sampleFps.toStringAsFixed(3)),
+        'size': [frameHeight, frameWidth],
+        'dt_ms': sampleInterval.inMilliseconds,
+        'duration_s': double.parse(durationSec.toStringAsFixed(3)),
+      },
+      'sampling': {
+        'strategy': 'timestamp',
+        'dt_ms': sampleInterval.inMilliseconds,
+      },
+      'models': {
+        'yolo': {'name': 'yolov8n-person.onnx', 'input': [640, 640]},
+        'rtmpose': {'name': p.basename(rtmModel), 'input': [256, 192]},
+        'motionbert': {'name': 'MB_ft_h36m.bin', 'clip_len_max': 243, 'stride': 81},
+      },
+      'counts': {
+        'frames_2d': frames2d,
+        'clips_3d': windows3d,
+      },
+    };
+    await meta.writeAsString(const JsonEncoder.withIndent('  ').convert(payload));
+    return meta;
   }
-
-  double _area(List<double> b) => math.max(0.0, b[2] - b[0]) * math.max(0.0, b[3] - b[1]);
 }
 
-class Pose2DRecord {
-  Pose2DRecord({
+class _YoloRecord {
+  _YoloRecord({
     required this.t,
     required this.tsMs,
-    required this.frameIndex,
-    required this.frameSize,
-    required this.bbox,
-    required this.letterbox,
-    required this.keypoints,
+    required this.frameIdx,
+    required this.bboxRaw,
+    required this.score,
+    this.frameWidth,
+    this.frameHeight,
+    this.bboxNorm,
   });
 
   final double t;
   final int tsMs;
-  final int frameIndex;
-  final List<int> frameSize;
-  final _Det? bbox;
-  final _LetterboxMeta letterbox;
-  final List<List<double>> keypoints;
-
-  Map<String, dynamic> toJson() {
-    final double w = frameSize[0].toDouble();
-    final double h = frameSize[1].toDouble();
-    final List<double> bboxNorm;
-    if (bbox == null) {
-      bboxNorm = [0.0, 0.0, 0.0, 0.0];
-    } else {
-      bboxNorm = [
-        (bbox!.x1 / w).clamp(0.0, 1.0),
-        (bbox!.y1 / h).clamp(0.0, 1.0),
-        (bbox!.x2 / w).clamp(0.0, 1.0),
-        (bbox!.y2 / h).clamp(0.0, 1.0),
-      ].map((v) => double.parse(v.toStringAsFixed(6))).toList();
-    }
-
-    return {
-      't': double.parse(t.toStringAsFixed(3)),
-      'ts_ms': tsMs,
-      'frame_idx': frameIndex,
-      'frame_size': frameSize,
-      'bbox_norm': bboxNorm,
-      'lb_params': {
-        'r': double.parse(letterbox.r.toStringAsFixed(6)),
-        'dw': double.parse(letterbox.dw.toStringAsFixed(3)),
-        'dh': double.parse(letterbox.dh.toStringAsFixed(3)),
-        'in_w': letterbox.inW,
-        'in_h': letterbox.inH,
-        'out': [letterbox.outW, letterbox.outH],
-      },
-      'kpt_coco': keypoints
-          .map((kp) => [
-                double.parse(kp[0].toStringAsFixed(3)),
-                double.parse(kp[1].toStringAsFixed(3)),
-                double.parse(kp[2].toStringAsFixed(3)),
-              ])
-          .toList(),
-    };
-  }
-}
-
-class _ChainData {
-  _ChainData({
-    required this.letterbox,
-    required this.bbox,
-    required this.coco,
-    required this.h36m,
-  });
-
-  final _LetterboxMeta letterbox;
-  final _Det? bbox;
-  final List<List<double>> coco;
-  final List<List<double>> h36m;
-}
-
-class _Det {
-  _Det(this.x1, this.y1, this.x2, this.y2, this.score);
-
-  final double x1;
-  final double y1;
-  final double x2;
-  final double y2;
+  final int frameIdx;
+  final List<double> bboxRaw;
   final double score;
-}
+  final int? frameWidth;
+  final int? frameHeight;
+  final List<double>? bboxNorm;
 
-class _LetterboxMeta {
-  _LetterboxMeta({
-    required this.inW,
-    required this.inH,
-    required this.outW,
-    required this.outH,
-    required this.r,
-    required this.dw,
-    required this.dh,
-  });
-
-  final int inW;
-  final int inH;
-  final int outW;
-  final int outH;
-  final double r;
-  final double dw;
-  final double dh;
-}
-
-class _LetterboxResult {
-  _LetterboxResult({required this.image, required this.meta});
-
-  final img.Image image;
-  final _LetterboxMeta meta;
+  static _YoloRecord? fromJson(Map<String, dynamic> json) {
+    final List<dynamic>? raw = json['bbox_raw'] as List<dynamic>?;
+    if (raw == null || raw.length != 4) return null;
+    final List<double> bbox =
+        raw.map((e) => (e as num).toDouble()).toList(growable: false);
+    final frameSize = json['frame_size'] as List<dynamic>?;
+    final width = frameSize != null && frameSize.length >= 2
+        ? (frameSize[1] as num).toInt()
+        : null;
+    final height = frameSize != null && frameSize.length >= 2
+        ? (frameSize[0] as num).toInt()
+        : null;
+    final norm = json['bbox_norm'] as List<dynamic>?;
+    return _YoloRecord(
+      t: (json['t'] as num?)?.toDouble() ?? 0.0,
+      tsMs: (json['ts_ms'] as num?)?.toInt() ?? 0,
+      frameIdx: (json['frame_idx'] as num?)?.toInt() ?? 0,
+      bboxRaw: bbox,
+      score: (json['score'] as num?)?.toDouble() ?? 0.0,
+      frameWidth: width,
+      frameHeight: height,
+      bboxNorm: norm?.map((e) => (e as num).toDouble()).toList(),
+    );
+  }
 }
 
 class _CropMeta {
   _CropMeta({
-    required this.roiX,
-    required this.roiY,
-    required this.roiW,
-    required this.roiH,
-    required this.outW,
-    required this.outH,
+    required this.x1,
+    required this.y1,
+    required this.width,
+    required this.height,
   });
 
-  final double roiX;
-  final double roiY;
-  final double roiW;
-  final double roiH;
-  final int outW;
-  final int outH;
+  final double x1;
+  final double y1;
+  final int width;
+  final int height;
 }
 
 class _CropResult {
   _CropResult({required this.image, required this.meta});
-
   final img.Image image;
   final _CropMeta meta;
+}
+
+class _LetterboxMeta {
+  _LetterboxMeta({
+    required this.r,
+    required this.dw,
+    required this.dh,
+    required this.inW,
+    required this.inH,
+    required this.outW,
+    required this.outH,
+  });
+
+  final double r;
+  final double dw;
+  final double dh;
+  final int inW;
+  final int inH;
+  final int outW;
+  final int outH;
+
+  Map<String, dynamic> toJson() => {
+        'r': double.parse(r.toStringAsFixed(6)),
+        'dw': double.parse(dw.toStringAsFixed(3)),
+        'dh': double.parse(dh.toStringAsFixed(3)),
+        'in_w': inW,
+        'in_h': inH,
+        'out': [outH, outW],
+      };
+}
+
+class _LetterboxResult {
+  _LetterboxResult({required this.image, required this.meta});
+  final img.Image image;
+  final _LetterboxMeta meta;
 }


### PR DESCRIPTION
## Summary
- update the live pose engine to record yolo_person.jsonl entries while streaming
- rebuild the offline video pose pipeline to consume recorded video plus YOLO detections and emit coco_2d/out_3d/meta artifacts
- route run3DForSession and the recording flow through the new pipeline and refresh user-facing file references

## Testing
- Not run (Flutter/Dart tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_690a3e0ecb18832f8cc6906ed4ce3643